### PR TITLE
chore: Run `cargo fmt`

### DIFF
--- a/pybindings/src/lib.rs
+++ b/pybindings/src/lib.rs
@@ -1,8 +1,8 @@
-use quizx::graph::*;
-use quizx::extract::ToCircuit;
+use num::Rational;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use num::Rational;
+use quizx::extract::ToCircuit;
+use quizx::graph::*;
 
 #[pymodule]
 fn libquizx(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -39,11 +39,16 @@ fn full_simp(g: &mut VecGraph) {
 
 #[pyfunction]
 fn extract_circuit(g: &mut VecGraph) -> Circuit {
-    Circuit { c: g.g.into_circuit().unwrap(), s: None }
+    Circuit {
+        c: g.g.into_circuit().unwrap(),
+        s: None,
+    }
 }
 
 #[pyclass]
-struct CircuitStats { s: quizx::circuit::CircuitStats }
+struct CircuitStats {
+    s: quizx::circuit::CircuitStats,
+}
 
 /// A (mostly) opaque wrapper for quizx circuits
 #[pyclass]
@@ -52,91 +57,148 @@ struct Circuit {
     s: Option<quizx::circuit::CircuitStats>,
 }
 
-
 #[pymethods]
 impl Circuit {
     #[staticmethod]
     fn from_qasm(qasm: String) -> Circuit {
-        Circuit { c: quizx::circuit::Circuit::from_qasm(&qasm).unwrap(), s: None }
+        Circuit {
+            c: quizx::circuit::Circuit::from_qasm(&qasm).unwrap(),
+            s: None,
+        }
     }
 
     #[staticmethod]
     fn load(file: String) -> Circuit {
-        Circuit { c: quizx::circuit::Circuit::from_file(&file).unwrap(), s: None }
+        Circuit {
+            c: quizx::circuit::Circuit::from_file(&file).unwrap(),
+            s: None,
+        }
     }
 
-    fn to_qasm(&self) -> String { self.c.to_qasm() }
-    fn to_graph(&self) -> VecGraph { VecGraph { g: self.c.to_graph() } }
+    fn to_qasm(&self) -> String {
+        self.c.to_qasm()
+    }
+    fn to_graph(&self) -> VecGraph {
+        VecGraph {
+            g: self.c.to_graph(),
+        }
+    }
 
-    fn num_gates(&self) -> usize { self.c.num_gates() }
+    fn num_gates(&self) -> usize {
+        self.c.num_gates()
+    }
     fn stats(&mut self) -> CircuitStats {
         // generate stats the first time this method is called
-        if self.s.is_none() { self.s = Some(self.c.stats()); }
+        if self.s.is_none() {
+            self.s = Some(self.c.stats());
+        }
         CircuitStats { s: self.s.unwrap() }
     }
 }
 
 #[pymethods]
 impl CircuitStats {
-    fn qubits(&self) -> usize { self.s.qubits }
-    fn total(&self) -> usize { self.s.total }
-    fn oneq(&self) -> usize { self.s.oneq }
-    fn twoq(&self) -> usize { self.s.twoq }
-    fn moreq(&self) -> usize { self.s.moreq }
-    fn cliff(&self) -> usize { self.s.cliff }
-    fn non_cliff(&self) -> usize { self.s.non_cliff }
-    fn to_string(&self) -> String { self.s.to_string() }
+    fn qubits(&self) -> usize {
+        self.s.qubits
+    }
+    fn total(&self) -> usize {
+        self.s.total
+    }
+    fn oneq(&self) -> usize {
+        self.s.oneq
+    }
+    fn twoq(&self) -> usize {
+        self.s.twoq
+    }
+    fn moreq(&self) -> usize {
+        self.s.moreq
+    }
+    fn cliff(&self) -> usize {
+        self.s.cliff
+    }
+    fn non_cliff(&self) -> usize {
+        self.s.non_cliff
+    }
+    fn to_string(&self) -> String {
+        self.s.to_string()
+    }
 }
 
 /// Wrapper for quizx::vec_graph::Graph
 #[pyclass]
-struct VecGraph { pub g: quizx::vec_graph::Graph }
+struct VecGraph {
+    pub g: quizx::vec_graph::Graph,
+}
 
 #[pymethods]
 impl VecGraph {
     #[new]
     fn new() -> VecGraph {
-        VecGraph { g: quizx::vec_graph::Graph::new() }
+        VecGraph {
+            g: quizx::vec_graph::Graph::new(),
+        }
     }
 
-    fn vindex(&self) -> usize { self.g.vindex() }
-    fn neighbor_at(&self, v: usize, n: usize) -> usize { self.g.neighbor_at(v, n) }
-    fn num_vertices(&self) -> usize { self.g.num_vertices() }
-    fn num_edges(&self) -> usize { self.g.num_edges() }
-    fn add_vertex(&mut self,
-                  ty_num: u8,
-                  qubit: i32,
-                  row: i32,
-                  phase: (isize, isize)) -> usize
-    {
+    fn vindex(&self) -> usize {
+        self.g.vindex()
+    }
+    fn neighbor_at(&self, v: usize, n: usize) -> usize {
+        self.g.neighbor_at(v, n)
+    }
+    fn num_vertices(&self) -> usize {
+        self.g.num_vertices()
+    }
+    fn num_edges(&self) -> usize {
+        self.g.num_edges()
+    }
+    fn add_vertex(&mut self, ty_num: u8, qubit: i32, row: i32, phase: (isize, isize)) -> usize {
         let ty = match ty_num {
             1 => VType::Z,
             2 => VType::X,
             3 => VType::H,
-            _ => VType::B
+            _ => VType::B,
         };
         let phase = Rational::new(phase.0, phase.1);
         self.g.add_vertex_with_data(VData {
-            ty, phase, qubit, row,
+            ty,
+            phase,
+            qubit,
+            row,
         })
     }
 
-    fn contains_vertex(&self, v: usize) -> bool { self.g.contains_vertex(v) }
+    fn contains_vertex(&self, v: usize) -> bool {
+        self.g.contains_vertex(v)
+    }
 
     fn add_edge(&mut self, e: (usize, usize), et_num: u8) {
-        let et = match et_num { 2 => EType::H, _ => EType::N };
+        let et = match et_num {
+            2 => EType::H,
+            _ => EType::N,
+        };
         self.g.add_edge_with_type(e.0, e.1, et)
     }
 
     fn add_edge_smart(&mut self, e: (usize, usize), et_num: u8) {
-        let et = match et_num { 1 => EType::H, _ => EType::N };
+        let et = match et_num {
+            1 => EType::H,
+            _ => EType::N,
+        };
         self.g.add_edge_smart(e.0, e.1, et)
     }
 
-    fn remove_vertex(&mut self, v: usize) { self.g.remove_vertex(v) }
-    fn remove_edge(&mut self, e: (usize, usize)) { self.g.remove_edge(e.0, e.1) }
-    fn degree(&self, v: usize) -> usize { self.g.degree(v) }
-    fn connected(&self, s: usize, t: usize) -> bool { self.g.connected(s,t) }
+    fn remove_vertex(&mut self, v: usize) {
+        self.g.remove_vertex(v)
+    }
+    fn remove_edge(&mut self, e: (usize, usize)) {
+        self.g.remove_edge(e.0, e.1)
+    }
+    fn degree(&self, v: usize) -> usize {
+        self.g.degree(v)
+    }
+    fn connected(&self, s: usize, t: usize) -> bool {
+        self.g.connected(s, t)
+    }
 
     fn vertex_type(&self, v: usize) -> u8 {
         match self.g.vertex_type(v) {
@@ -158,7 +220,7 @@ impl VecGraph {
     }
 
     fn edge_type(&self, e: (usize, usize)) -> u8 {
-        match self.g.edge_type_opt(e.0,e.1) {
+        match self.g.edge_type_opt(e.0, e.1) {
             Some(EType::N) => 1,
             Some(EType::H) => 2,
             None => 0,
@@ -166,8 +228,8 @@ impl VecGraph {
     }
 
     fn set_edge_type(&mut self, e: (usize, usize), et_num: u8) {
-        self.g.set_edge_type(e.0, e.1,
-          if et_num == 2 { EType::H } else { EType::N });
+        self.g
+            .set_edge_type(e.0, e.1, if et_num == 2 { EType::H } else { EType::N });
     }
 
     fn phase(&self, v: usize) -> (isize, isize) {
@@ -183,53 +245,86 @@ impl VecGraph {
         self.g.add_to_phase(v, Rational::new(phase.0, phase.1));
     }
 
-    fn qubit(&mut self, v: usize) -> i32 { self.g.qubit(v) }
-    fn set_qubit(&mut self, v: usize, q: i32) { self.g.set_qubit(v, q); }
-    fn row(&mut self, v: usize) -> i32 { self.g.row(v) }
-    fn set_row(&mut self, v: usize, r: i32) { self.g.set_row(v, r); }
+    fn qubit(&mut self, v: usize) -> i32 {
+        self.g.qubit(v)
+    }
+    fn set_qubit(&mut self, v: usize, q: i32) {
+        self.g.set_qubit(v, q);
+    }
+    fn row(&mut self, v: usize) -> i32 {
+        self.g.row(v)
+    }
+    fn set_row(&mut self, v: usize, r: i32) {
+        self.g.set_row(v, r);
+    }
 
-    fn inputs(&self) -> Vec<V> { self.g.inputs().clone() }
-    fn num_inputs(&self) -> usize { self.g.inputs().len() }
-    fn set_inputs(&mut self, inputs: Vec<V>) { self.g.set_inputs(inputs) }
-    fn outputs(&self) -> Vec<V> { self.g.outputs().clone() }
-    fn num_outputs(&self) -> usize { self.g.outputs().len() }
-    fn set_outputs(&mut self, outputs: Vec<V>) { self.g.set_outputs(outputs) }
+    fn inputs(&self) -> Vec<V> {
+        self.g.inputs().clone()
+    }
+    fn num_inputs(&self) -> usize {
+        self.g.inputs().len()
+    }
+    fn set_inputs(&mut self, inputs: Vec<V>) {
+        self.g.set_inputs(inputs)
+    }
+    fn outputs(&self) -> Vec<V> {
+        self.g.outputs().clone()
+    }
+    fn num_outputs(&self) -> usize {
+        self.g.outputs().len()
+    }
+    fn set_outputs(&mut self, outputs: Vec<V>) {
+        self.g.set_outputs(outputs)
+    }
 }
 
 #[pyclass]
 struct Decomposer {
-    d: quizx::decompose::Decomposer<quizx::vec_graph::Graph>
+    d: quizx::decompose::Decomposer<quizx::vec_graph::Graph>,
 }
-
-
 
 #[pymethods]
 impl Decomposer {
     #[staticmethod]
     fn empty() -> Decomposer {
-        Decomposer { d: quizx::decompose::Decomposer::empty() }
+        Decomposer {
+            d: quizx::decompose::Decomposer::empty(),
+        }
     }
 
     #[new]
     fn new(g: &VecGraph) -> Decomposer {
-        Decomposer { d: quizx::decompose::Decomposer::new(&g.g) }
+        Decomposer {
+            d: quizx::decompose::Decomposer::new(&g.g),
+        }
     }
 
     fn graphs(&self) -> PyResult<Vec<VecGraph>> {
         let mut gs = vec![];
-        for (_a,g) in &self.d.stack {
-            gs.push(VecGraph {g: g.clone() });
+        for (_a, g) in &self.d.stack {
+            gs.push(VecGraph { g: g.clone() });
         }
         Ok(gs)
     }
 
-    fn apply_optimizations(&mut self, b: bool) { 
-        if b { self.d.with_simp(quizx::decompose::SimpFunc::FullSimp); } 
-        else { self.d.with_simp(quizx::decompose::SimpFunc::NoSimp); }
+    fn apply_optimizations(&mut self, b: bool) {
+        if b {
+            self.d.with_simp(quizx::decompose::SimpFunc::FullSimp);
+        } else {
+            self.d.with_simp(quizx::decompose::SimpFunc::NoSimp);
+        }
     }
 
-    fn max_terms(&self) -> f64 { self.d.max_terms() }
-    fn decomp_top(&mut self) { self.d.decomp_top(); }
-    fn decomp_all(&mut self) { self.d.decomp_all(); }
-    fn decomp_until_depth(&mut self, depth: usize) { self.d.decomp_until_depth(depth); }
+    fn max_terms(&self) -> f64 {
+        self.d.max_terms()
+    }
+    fn decomp_top(&mut self) {
+        self.d.decomp_top();
+    }
+    fn decomp_all(&mut self) {
+        self.d.decomp_all();
+    }
+    fn decomp_until_depth(&mut self, depth: usize) {
+        self.d.decomp_until_depth(depth);
+    }
 }

--- a/quizx/src/annealer.rs
+++ b/quizx/src/annealer.rs
@@ -16,24 +16,24 @@
 
 // use crate::circuit::*;
 // use crate::gate::*;
-use crate::graph::*;
-use crate::extract::*;
 use crate::basic_rules::*;
+use crate::extract::*;
+use crate::graph::*;
 
-use rand::{SeedableRng, Rng};
 use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 pub struct Annealer<G: GraphLike> {
     pub g: G,
     rng: StdRng,
-    scoref: fn (&G) -> usize,
-    actions: Vec<fn (&mut StdRng, &mut G)>,
+    scoref: fn(&G) -> usize,
+    actions: Vec<fn(&mut StdRng, &mut G)>,
     temp: f64,
     cool: f64,
     iters: usize,
 }
 
-impl <G: GraphLike> Annealer<G> {
+impl<G: GraphLike> Annealer<G> {
     pub fn extract_2q_score(g: &G) -> usize {
         let c = g.to_circuit().unwrap();
         c.stats().twoq
@@ -41,21 +41,33 @@ impl <G: GraphLike> Annealer<G> {
 
     pub fn random_local_comp(rng: &mut StdRng, g: &mut G) {
         let candidates: Vec<_> = g.vertices().filter(|&v| check_local_comp(g, v)).collect();
-        if candidates.is_empty() { return; }
+        if candidates.is_empty() {
+            return;
+        }
         let i = rng.gen_range(0..candidates.len());
         local_comp(g, candidates[i]);
     }
 
     pub fn random_pivot(rng: &mut StdRng, g: &mut G) {
-        let candidates: Vec<_> = g.edges().filter(|&(s,t,_)| check_pivot(g, s, t)).collect();
-        if candidates.is_empty() { return; }
+        let candidates: Vec<_> = g
+            .edges()
+            .filter(|&(s, t, _)| check_pivot(g, s, t))
+            .collect();
+        if candidates.is_empty() {
+            return;
+        }
         let i = rng.gen_range(0..candidates.len());
         pivot(g, candidates[i].0, candidates[i].1);
     }
 
     pub fn random_gen_pivot(rng: &mut StdRng, g: &mut G) {
-        let candidates: Vec<_> = g.edges().filter(|&(s,t,_)| check_gen_pivot(g, s, t)).collect();
-        if candidates.is_empty() { return; }
+        let candidates: Vec<_> = g
+            .edges()
+            .filter(|&(s, t, _)| check_gen_pivot(g, s, t))
+            .collect();
+        if candidates.is_empty() {
+            return;
+        }
         let i = rng.gen_range(0..candidates.len());
         gen_pivot(g, candidates[i].0, candidates[i].1);
     }
@@ -72,31 +84,51 @@ impl <G: GraphLike> Annealer<G> {
         }
     }
 
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.rng = StdRng::seed_from_u64(seed);
+        self
+    }
+    pub fn scoref(&mut self, scoref: fn(&G) -> usize) -> &mut Self {
+        self.scoref = scoref;
+        self
+    }
 
-    pub fn seed(&mut self, seed: u64) -> &mut Self { self.rng = StdRng::seed_from_u64(seed); self }
-    pub fn scoref(&mut self, scoref: fn (&G) -> usize) -> &mut Self
-    { self.scoref = scoref; self }
-
-    pub fn temp(&mut self, temp: f64) -> &mut Self { self.temp = temp; self }
-    pub fn cool(&mut self, cool: f64) -> &mut Self { self.cool = cool; self }
-    pub fn iters(&mut self, iters: usize) -> &mut Self { self.iters = iters; self }
+    pub fn temp(&mut self, temp: f64) -> &mut Self {
+        self.temp = temp;
+        self
+    }
+    pub fn cool(&mut self, cool: f64) -> &mut Self {
+        self.cool = cool;
+        self
+    }
+    pub fn iters(&mut self, iters: usize) -> &mut Self {
+        self.iters = iters;
+        self
+    }
 
     pub fn anneal(&mut self) {
-        if self.actions.is_empty() { return; }
+        if self.actions.is_empty() {
+            return;
+        }
         let mut temp = self.temp;
         let mut current_score = (self.scoref)(&self.g) as isize;
 
         let chunk = self.iters / 20;
         for it in 0..self.iters {
-            if it % chunk == 0 { println!("{}/{}", it, self.iters); }
+            if it % chunk == 0 {
+                println!("{}/{}", it, self.iters);
+            }
             // select and action uniformly at random
             let i = self.rng.gen_range(0..self.actions.len());
             let mut g = self.g.clone();
             self.actions[i](&mut self.rng, &mut g);
             let new_score = (self.scoref)(&self.g) as isize;
-            if new_score < current_score || 
-                (temp != 0.0 &&
-                 self.rng.gen_bool(f64::min(1.0, ((current_score - new_score) as f64 / temp).exp())))
+            if new_score < current_score
+                || (temp != 0.0
+                    && self.rng.gen_bool(f64::min(
+                        1.0,
+                        ((current_score - new_score) as f64 / temp).exp(),
+                    )))
             {
                 self.g = g;
                 current_score = new_score;

--- a/quizx/src/bin/big_simp.rs
+++ b/quizx/src/bin/big_simp.rs
@@ -16,15 +16,14 @@
 
 // use std::time::Instant;
 use quizx::circuit::*;
-use quizx::vec_graph::*;
-use quizx::simplify::*;
 use quizx::extract::*;
+use quizx::simplify::*;
+use quizx::vec_graph::*;
 use std::time::Instant;
 // use quizx::tensor::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let c = Circuit::from_file("../circuits/large/hwb10.qasm")?
-                    .to_basic_gates();
+    let c = Circuit::from_file("../circuits/large/hwb10.qasm")?.to_basic_gates();
     println!("stats before: {}", c.stats());
     let mut g: Graph = c.to_graph();
 
@@ -36,21 +35,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let time = Instant::now();
     println!("extracting...");
 
-    let result = g.extractor()
-        .gflow()
-        .up_to_perm()
-        .extract();
+    let result = g.extractor().gflow().up_to_perm().extract();
 
     match result {
         Ok(c1) => {
             println!("Done in {:.2?}", time.elapsed());
             println!("extracted ok");
             println!("stats after: {}", c1.stats());
-        },
+        }
         Err(ExtractError(msg, _c, _g)) => {
             println!("extract failed: {}", msg);
             // println!("{}\n\n{}\n\n{}", msg, _c, _g.to_dot());
-        },
+        }
     }
     Ok(())
 }

--- a/quizx/src/bin/cnot_anneal.rs
+++ b/quizx/src/bin/cnot_anneal.rs
@@ -14,11 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use quizx::annealer::*;
 use quizx::circuit::*;
+use quizx::extract::*;
 use quizx::hash_graph::*;
 use quizx::simplify::*;
-use quizx::extract::*;
-use quizx::annealer::*;
 
 use std::time::Instant;
 use std::{thread, time};
@@ -43,33 +43,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Annealing...");
     let time = Instant::now();
     let mut annealer = Annealer::new(g);
-    annealer
-        .seed(1337)
-        .temp(25.0)
-        .anneal();
+    annealer.seed(1337).temp(25.0).anneal();
     g = annealer.g;
     println!("Done annealing in {:.2?}", time.elapsed());
 
     println!("Extracting circuit...");
     let time = Instant::now();
-    let result = g.extractor()
+    let result = g
+        .extractor()
         .gflow()
         // .up_to_perm()
         .extract();
-
 
     match result {
         Ok(_c1) => {
             println!("Done in {:.2?}", time.elapsed());
             println!("extracted ok");
             println!("After: {}", _c1.stats());
-        },
+        }
         Err(ExtractError(msg, _c, _g)) => {
             println!("extract failed: {}", msg);
             // println!("\n\n{}", _g.to_dot());
-        },
+        }
     }
-
 
     thread::sleep(time::Duration::from_millis(100));
     Ok(())

--- a/quizx/src/bin/compute_tensor.rs
+++ b/quizx/src/bin/compute_tensor.rs
@@ -14,19 +14,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // use quizx::graph::*;
 // use quizx::vec_graph::Graph;
 // use quizx::tensor::ToTensor;
 // use quizx::basic_rules::*;
 // use std::time::Instant;
 use ndarray::prelude::*;
-use ndarray::{Axis,stack};
+use ndarray::{stack, Axis};
 
 fn main() {
     // let a1 = array![[1, 0],[0, 1]];
-    let a = array![[1, 2],[3, 4]];
-    let b = stack![Axis(0),a,a];
+    let a = array![[1, 2], [3, 4]];
+    let b = stack![Axis(0), a, a];
     // let sh = Vec::from(b.shape());
     println!("{}", b);
     println!("{:?}", b.shape());

--- a/quizx/src/bin/gauss.rs
+++ b/quizx/src/bin/gauss.rs
@@ -11,7 +11,7 @@ fn main() {
     let u = Mat2::unit_vector(3, 1);
     println!("{}", u);
 
-    let mut chunks: FxHashMap<&[u32],usize> = FxHashMap::default();
+    let mut chunks: FxHashMap<&[u32], usize> = FxHashMap::default();
 
     let v = [1, 0, 1, 1, 0, 1];
     chunks.insert(&v[0..3], 1);

--- a/quizx/src/bin/pauli_gadget_stabrank.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank.rs
@@ -14,37 +14,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Instant,Duration};
-use std::env;
-use std::fs;
-use std::io::{self,Write};
 use itertools::Itertools;
 use quizx::circuit::*;
+use quizx::decompose::{terms_for_tcount, Decomposer};
 use quizx::graph::*;
 use quizx::scalar::*;
 use quizx::tensor::*;
 use quizx::vec_graph::Graph;
-use quizx::decompose::{terms_for_tcount,Decomposer};
 use rand::rngs::StdRng;
-use rand::{SeedableRng, Rng};
+use rand::{Rng, SeedableRng};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let debug = true;
     let args: Vec<_> = env::args().collect();
-    let (qs, depth, min_weight, max_weight, nsamples, seed) =
-        if args.len() >= 6 {
-            (args[1].parse().unwrap(),
+    let (qs, depth, min_weight, max_weight, nsamples, seed) = if args.len() >= 6 {
+        (
+            args[1].parse().unwrap(),
             args[2].parse().unwrap(),
             args[3].parse().unwrap(),
             args[4].parse().unwrap(),
             args[5].parse().unwrap(),
-            args[6].parse().unwrap())
-        } else {
-            (100, 30, 10, 10, 1, 1337)
-            // (13, 15, 2, 4, 3, 1337)
-        };
-    if debug { println!("qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
-                        qs, depth, min_weight, max_weight, seed); }
+            args[6].parse().unwrap(),
+        )
+    } else {
+        (100, 30, 10, 10, 1, 1337)
+        // (13, 15, 2, 4, 3, 1337)
+    };
+    if debug {
+        println!(
+            "qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
+            qs, depth, min_weight, max_weight, seed
+        );
+    }
     let c = Circuit::random_pauli_gadget()
         .qubits(qs)
         .depth(depth)
@@ -57,13 +62,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut g: Graph = c.to_graph();
     let tcount = g.tcount();
-    if debug { println!("g has T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has T-count: {}", g.tcount());
+    }
 
     let time_all = Instant::now();
     quizx::simplify::full_simp(&mut g);
-    if debug { println!("g has reduced T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has reduced T-count: {}", g.tcount());
+    }
 
     let mut tcounts = vec![];
     let mut terms = 0;
@@ -119,45 +126,60 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // randomly pick an outcome according to p
-            let outcome =
-                if rng.gen_bool(p) {
-                    // outcome 1: let |g> = |h> = (<1| ⊗ I)|g>
-                    g.plug_output(0, BasisElem::Z1);
-                    // and save <g|g> = <h|h>
-                    renorm = prob.clone();
-                    1
-                } else {
-                    // outcome 0: for |h'> = (<0| ⊗ I)|g>
-                    //   we have <g|g> = <h'|h'> + <h|h>, so <h'|h'> = <g|g> - <h|h>
+            let outcome = if rng.gen_bool(p) {
+                // outcome 1: let |g> = |h> = (<1| ⊗ I)|g>
+                g.plug_output(0, BasisElem::Z1);
+                // and save <g|g> = <h|h>
+                renorm = prob.clone();
+                1
+            } else {
+                // outcome 0: for |h'> = (<0| ⊗ I)|g>
+                //   we have <g|g> = <h'|h'> + <h|h>, so <h'|h'> = <g|g> - <h|h>
 
-                    // let |g> = |h'>
-                    g.plug_output(0, BasisElem::Z0);
+                // let |g> = |h'>
+                g.plug_output(0, BasisElem::Z0);
 
-                    // and <g|g> = <h'|h'>
-                    prob = renorm + Scalar::minus_one() * prob;
-                    renorm = prob.clone();
+                // and <g|g> = <h'|h'>
+                prob = renorm + Scalar::minus_one() * prob;
+                renorm = prob.clone();
 
-                    p = 1.0 - p; // complement probability for output below
+                p = 1.0 - p; // complement probability for output below
 
-                    0
-                };
+                0
+            };
 
             meas.push(outcome);
 
-            if debug { println!("{} (p: {}, terms: {}, time: {:.2?})", outcome, p, d.nterms, time_single.elapsed()); }
+            if debug {
+                println!(
+                    "{} (p: {}, terms: {}, time: {:.2?})",
+                    outcome,
+                    p,
+                    d.nterms,
+                    time_single.elapsed()
+                );
+            }
             terms += d.nterms;
         }
 
-        println!("Got: {} (P: {}, re(P) ~ {})", meas.iter().format(""), prob, prob.float_value().re);
+        println!(
+            "Got: {} (P: {}, re(P) ~ {})",
+            meas.iter().format(""),
+            prob,
+            prob.float_value().re
+        );
         time += time_all.elapsed();
 
         // for small numbers of qubits, it is feasible to check the final probablility
-        success = success &&
-            if qs <= 15 {
+        success = success
+            && if qs <= 15 {
                 print!("Checking tensor...");
                 io::stdout().flush().unwrap();
                 let mut check: Graph = c.to_graph();
-                let effect: Vec<_> = meas.iter().map(|&b| if b == 0 { BasisElem::Z0 } else { BasisElem::Z1 }).collect();
+                let effect: Vec<_> = meas
+                    .iter()
+                    .map(|&b| if b == 0 { BasisElem::Z0 } else { BasisElem::Z1 })
+                    .collect();
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
@@ -174,21 +196,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 true
             };
 
-
         if debug {
-            println!("Circuit with {} qubits and T-count {} simulated in {:.2?}", qs, tcount, time);
+            println!(
+                "Circuit with {} qubits and T-count {} simulated in {:.2?}",
+                qs, tcount, time
+            );
         }
     }
 
     let naive: f64 = (nsamples as f64) * (qs as f64) * terms_for_tcount(2 * tcount);
     let no_simp: f64 = tcounts.iter().map(|&t| terms_for_tcount(t)).sum();
-    println!("Got {} terms across all samples ({:+e} naive)", terms, naive);
+    println!(
+        "Got {} terms across all samples ({:+e} naive)",
+        terms, naive
+    );
 
     let data = format!("\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{:+e}\",\"{:+e}\"\n",
                        qs, depth, tcount, min_weight, max_weight, nsamples, seed, terms, time.as_millis(), tcounts.iter().format(","), no_simp, naive);
     if success {
         print!("OK {}", data);
-        fs::write(&format!("pauli_gadget_{}_{}_{}_{}_{}_{}", qs, depth, min_weight, max_weight, nsamples, seed), data).expect("Unable to write file");
+        fs::write(
+            &format!(
+                "pauli_gadget_{}_{}_{}_{}_{}_{}",
+                qs, depth, min_weight, max_weight, nsamples, seed
+            ),
+            data,
+        )
+        .expect("Unable to write file");
     } else {
         print!("FAILED {}", data);
     }

--- a/quizx/src/bin/pauli_gadget_stabrank_met.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank_met.rs
@@ -14,42 +14,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Instant,Duration};
-use std::env;
-use std::fs;
-use std::io::{self,Write};
 use itertools::Itertools;
 use quizx::circuit::*;
+use quizx::decompose::{terms_for_tcount, Decomposer};
 use quizx::graph::*;
 use quizx::scalar::*;
 use quizx::tensor::*;
 use quizx::vec_graph::Graph;
-use quizx::decompose::{terms_for_tcount,Decomposer};
 use rand::rngs::StdRng;
-use rand::{SeedableRng, Rng};
+use rand::{Rng, SeedableRng};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 fn meas_str(e: &[BasisElem]) -> String {
-    format!("{}", e.iter().map(|&b| if b == BasisElem::Z0 { 0 } else { 1 }).format(""))
+    format!(
+        "{}",
+        e.iter()
+            .map(|&b| if b == BasisElem::Z0 { 0 } else { 1 })
+            .format("")
+    )
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let debug = true;
     let args: Vec<_> = env::args().collect();
-    let (qs, depth, min_weight, max_weight, nsamples, metro_iters, seed) =
-        if args.len() >= 6 {
-            (args[1].parse().unwrap(),
+    let (qs, depth, min_weight, max_weight, nsamples, metro_iters, seed) = if args.len() >= 6 {
+        (
+            args[1].parse().unwrap(),
             args[2].parse().unwrap(),
             args[3].parse().unwrap(),
             args[4].parse().unwrap(),
             args[5].parse().unwrap(),
             args[6].parse().unwrap(),
-            args[7].parse().unwrap())
-        } else {
-            (50, 70, 2, 4, 1, 1000, 1337)
-            // (13, 15, 2, 4, 3, 1337)
-        };
-    if debug { println!("qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
-                        qs, depth, min_weight, max_weight, seed); }
+            args[7].parse().unwrap(),
+        )
+    } else {
+        (50, 70, 2, 4, 1, 1000, 1337)
+        // (13, 15, 2, 4, 3, 1337)
+    };
+    if debug {
+        println!(
+            "qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
+            qs, depth, min_weight, max_weight, seed
+        );
+    }
     let c = Circuit::random_pauli_gadget()
         .qubits(qs)
         .depth(depth)
@@ -62,13 +72,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut g: Graph = c.to_graph();
     let tcount = g.tcount();
-    if debug { println!("g has T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has T-count: {}", g.tcount());
+    }
 
     let time_all = Instant::now();
     quizx::simplify::full_simp(&mut g);
-    if debug { println!("g has reduced T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has reduced T-count: {}", g.tcount());
+    }
 
     let mut tcounts = vec![];
     let mut terms = 0;
@@ -86,11 +98,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // let time_single = Instant::now();
         // let mut terms_single = 0;
 
-        let mut effect: Vec<_> = (0..qs).map(|_| {
-            if rng.gen_bool(0.5) { BasisElem::Z0 } else { BasisElem::Z1 }
-        }).collect();
+        let mut effect: Vec<_> = (0..qs)
+            .map(|_| {
+                if rng.gen_bool(0.5) {
+                    BasisElem::Z0
+                } else {
+                    BasisElem::Z1
+                }
+            })
+            .collect();
 
-        if debug { println!("Starting metropolis at {}", meas_str(&effect)); }
+        if debug {
+            println!("Starting metropolis at {}", meas_str(&effect));
+        }
 
         for i in 0..metro_iters {
             let j = rng.gen_range(0..qs);
@@ -116,7 +136,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             terms += d.nterms;
 
             if debug {
-                println!("{} (P = {}, re(P) ~ {})", meas_str(&effect1), prob1, prob1.float_value().re);
+                println!(
+                    "{} (P = {}, re(P) ~ {})",
+                    meas_str(&effect1),
+                    prob1,
+                    prob1.float_value().re
+                );
             }
 
             if prob1.float_value().re > prob.float_value().re {
@@ -133,18 +158,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        let meas: Vec<_> = effect.iter().map(|&b| if b == BasisElem::Z0 { 0 } else { 1 }).collect();
+        let meas: Vec<_> = effect
+            .iter()
+            .map(|&b| if b == BasisElem::Z0 { 0 } else { 1 })
+            .collect();
 
-        println!("Finished at: {} (P = {}, re(P) ~ {})", meas.iter().format(""), prob, prob.float_value().re);
+        println!(
+            "Finished at: {} (P = {}, re(P) ~ {})",
+            meas.iter().format(""),
+            prob,
+            prob.float_value().re
+        );
         time += time_all.elapsed();
 
         // for small numbers of qubits, it is feasible to check the final probablility
-        success = success &&
-            if qs <= 15 {
+        success = success
+            && if qs <= 15 {
                 print!("Checking tensor...");
                 io::stdout().flush().unwrap();
                 let mut check: Graph = c.to_graph();
-                let effect: Vec<_> = meas.iter().map(|&b| if b == 0 { BasisElem::Z0 } else { BasisElem::Z1 }).collect();
+                let effect: Vec<_> = meas
+                    .iter()
+                    .map(|&b| if b == 0 { BasisElem::Z0 } else { BasisElem::Z1 })
+                    .collect();
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
@@ -161,21 +197,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 true
             };
 
-
         if debug {
-            println!("Circuit with {} qubits and T-count {} simulated in {:.2?}", qs, tcount, time);
+            println!(
+                "Circuit with {} qubits and T-count {} simulated in {:.2?}",
+                qs, tcount, time
+            );
         }
     }
 
     let naive: f64 = (nsamples as f64) * (qs as f64) * terms_for_tcount(2 * tcount);
     let no_simp: f64 = tcounts.iter().map(|&t| terms_for_tcount(t)).sum();
-    println!("Got {} terms across all samples ({:+e} naive)", terms, naive);
+    println!(
+        "Got {} terms across all samples ({:+e} naive)",
+        terms, naive
+    );
 
     let data = format!("\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{:+e}\",\"{:+e}\"\n",
                        qs, depth, tcount, min_weight, max_weight, nsamples, seed, terms, time.as_millis(), tcounts.iter().format(","), no_simp, naive);
     if success {
         print!("OK {}", data);
-        fs::write(&format!("pauli_gadget_{}_{}_{}_{}_{}_{}", qs, depth, min_weight, max_weight, nsamples, seed), data).expect("Unable to write file");
+        fs::write(
+            &format!(
+                "pauli_gadget_{}_{}_{}_{}_{}_{}",
+                qs, depth, min_weight, max_weight, nsamples, seed
+            ),
+            data,
+        )
+        .expect("Unable to write file");
     } else {
         print!("FAILED {}", data);
     }

--- a/quizx/src/bin/pauli_gadget_stabrank_ne.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank_ne.rs
@@ -14,39 +14,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Instant,Duration};
-use std::env;
-use std::fs;
-use std::io::{self,Write};
 use itertools::Itertools;
 use quizx::circuit::*;
+use quizx::decompose::{terms_for_tcount, Decomposer};
 use quizx::graph::*;
+use quizx::random_graph::*;
 use quizx::scalar::*;
 use quizx::tensor::*;
 use quizx::vec_graph::Graph;
-use quizx::decompose::{terms_for_tcount,Decomposer};
-use quizx::random_graph::*;
 use rand::rngs::StdRng;
-use rand::{SeedableRng, Rng};
+use rand::{Rng, SeedableRng};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let debug = true;
     let args: Vec<_> = env::args().collect();
     let (qs, depth, min_weight, max_weight, nsamples, norm_est_log_samples, seed) =
         if args.len() >= 6 {
-            (args[1].parse().unwrap(),
-            args[2].parse().unwrap(),
-            args[3].parse().unwrap(),
-            args[4].parse().unwrap(),
-            args[5].parse().unwrap(),
-            args[6].parse().unwrap(),
-            args[7].parse().unwrap())
+            (
+                args[1].parse().unwrap(),
+                args[2].parse().unwrap(),
+                args[3].parse().unwrap(),
+                args[4].parse().unwrap(),
+                args[5].parse().unwrap(),
+                args[6].parse().unwrap(),
+                args[7].parse().unwrap(),
+            )
         } else {
             (50, 30, 10, 10, 1, 3, 1337)
             // (13, 15, 2, 4, 3, 1337)
         };
-    if debug { println!("qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
-                        qs, depth, min_weight, max_weight, seed); }
+    if debug {
+        println!(
+            "qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
+            qs, depth, min_weight, max_weight, seed
+        );
+    }
     let c = Circuit::random_pauli_gadget()
         .qubits(qs)
         .depth(depth)
@@ -59,13 +65,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut g: Graph = c.to_graph();
     let tcount = g.tcount();
-    if debug { println!("g has T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has T-count: {}", g.tcount());
+    }
 
     let time_all = Instant::now();
     quizx::simplify::full_simp(&mut g);
-    if debug { println!("g has reduced T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has reduced T-count: {}", g.tcount());
+    }
 
     let mut tcounts = vec![];
     let mut terms = 0;
@@ -139,45 +147,60 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // randomly pick an outcome according to p
-            let outcome =
-                if rng.gen_bool(p) {
-                    // outcome 1: let |g> = |h> = (<1| ⊗ I)|g>
-                    g.plug_output(0, BasisElem::Z1);
-                    // and save <g|g> = <h|h>
-                    renorm = prob.clone();
-                    1
-                } else {
-                    // outcome 0: for |h'> = (<0| ⊗ I)|g>
-                    //   we have <g|g> = <h'|h'> + <h|h>, so <h'|h'> = <g|g> - <h|h>
+            let outcome = if rng.gen_bool(p) {
+                // outcome 1: let |g> = |h> = (<1| ⊗ I)|g>
+                g.plug_output(0, BasisElem::Z1);
+                // and save <g|g> = <h|h>
+                renorm = prob.clone();
+                1
+            } else {
+                // outcome 0: for |h'> = (<0| ⊗ I)|g>
+                //   we have <g|g> = <h'|h'> + <h|h>, so <h'|h'> = <g|g> - <h|h>
 
-                    // let |g> = |h'>
-                    g.plug_output(0, BasisElem::Z0);
+                // let |g> = |h'>
+                g.plug_output(0, BasisElem::Z0);
 
-                    // and <g|g> = <h'|h'>
-                    prob = renorm + Scalar::minus_one() * prob;
-                    renorm = prob.clone();
+                // and <g|g> = <h'|h'>
+                prob = renorm + Scalar::minus_one() * prob;
+                renorm = prob.clone();
 
-                    p = 1.0 - p; // complement probability for output below
+                p = 1.0 - p; // complement probability for output below
 
-                    0
-                };
+                0
+            };
 
             meas.push(outcome);
 
-            if debug { println!("{} (p: {}, terms: {}, time: {:.2?})", outcome, p, terms_single, time_single.elapsed()); }
+            if debug {
+                println!(
+                    "{} (p: {}, terms: {}, time: {:.2?})",
+                    outcome,
+                    p,
+                    terms_single,
+                    time_single.elapsed()
+                );
+            }
             terms += terms_single;
         }
 
-        println!("Got: {} (P: {}, re(P) ~ {})", meas.iter().format(""), prob, prob.float_value().re);
+        println!(
+            "Got: {} (P: {}, re(P) ~ {})",
+            meas.iter().format(""),
+            prob,
+            prob.float_value().re
+        );
         time += time_all.elapsed();
 
         // for small numbers of qubits, it is feasible to check the final probablility
-        success = success &&
-            if qs <= 15 {
+        success = success
+            && if qs <= 15 {
                 print!("Checking tensor...");
                 io::stdout().flush().unwrap();
                 let mut check: Graph = c.to_graph();
-                let effect: Vec<_> = meas.iter().map(|&b| if b == 0 { BasisElem::Z0 } else { BasisElem::Z1 }).collect();
+                let effect: Vec<_> = meas
+                    .iter()
+                    .map(|&b| if b == 0 { BasisElem::Z0 } else { BasisElem::Z1 })
+                    .collect();
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
@@ -194,21 +217,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 true
             };
 
-
         if debug {
-            println!("Circuit with {} qubits and T-count {} simulated in {:.2?}", qs, tcount, time);
+            println!(
+                "Circuit with {} qubits and T-count {} simulated in {:.2?}",
+                qs, tcount, time
+            );
         }
     }
 
     let naive: f64 = (nsamples as f64) * (qs as f64) * terms_for_tcount(2 * tcount);
     let no_simp: f64 = tcounts.iter().map(|&t| terms_for_tcount(t)).sum();
-    println!("Got {} terms across all samples ({:+e} naive)", terms, naive);
+    println!(
+        "Got {} terms across all samples ({:+e} naive)",
+        terms, naive
+    );
 
     let data = format!("\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{:+e}\",\"{:+e}\"\n",
                        qs, depth, tcount, min_weight, max_weight, nsamples, seed, terms, time.as_millis(), tcounts.iter().format(","), no_simp, naive);
     if success {
         print!("OK {}", data);
-        fs::write(&format!("pauli_gadget_{}_{}_{}_{}_{}_{}", qs, depth, min_weight, max_weight, nsamples, seed), data).expect("Unable to write file");
+        fs::write(
+            &format!(
+                "pauli_gadget_{}_{}_{}_{}_{}_{}",
+                qs, depth, min_weight, max_weight, nsamples, seed
+            ),
+            data,
+        )
+        .expect("Unable to write file");
     } else {
         print!("FAILED {}", data);
     }

--- a/quizx/src/bin/pauli_gadget_stabrank_single.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank_single.rs
@@ -14,41 +14,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{Instant,Duration};
-use std::env;
-use std::fs;
-use std::io::{self,Write};
 use itertools::Itertools;
 use quizx::circuit::*;
+use quizx::decompose::{terms_for_tcount, Decomposer};
 use quizx::graph::*;
 use quizx::scalar::*;
 use quizx::tensor::*;
 use quizx::vec_graph::Graph;
-use quizx::decompose::{terms_for_tcount,Decomposer};
 use rand::rngs::StdRng;
-use rand::{SeedableRng, Rng};
+use rand::{Rng, SeedableRng};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::time::{Duration, Instant};
 
 fn meas_str(e: &[BasisElem]) -> String {
-    format!("{}", e.iter().map(|&b| if b == BasisElem::Z0 { 0 } else { 1 }).format(""))
+    format!(
+        "{}",
+        e.iter()
+            .map(|&b| if b == BasisElem::Z0 { 0 } else { 1 })
+            .format("")
+    )
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let debug = true;
     let args: Vec<_> = env::args().collect();
-    let (qs, depth, min_weight, max_weight, nsamples, seed) =
-        if args.len() >= 6 {
-            (args[1].parse().unwrap(),
+    let (qs, depth, min_weight, max_weight, nsamples, seed) = if args.len() >= 6 {
+        (
+            args[1].parse().unwrap(),
             args[2].parse().unwrap(),
             args[3].parse().unwrap(),
             args[4].parse().unwrap(),
             args[5].parse().unwrap(),
-            args[6].parse().unwrap())
-        } else {
-            (50, 70, 4, 4, 1, 1337)
-            // (13, 15, 2, 4, 3, 1337)
-        };
-    if debug { println!("qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
-                        qs, depth, min_weight, max_weight, seed); }
+            args[6].parse().unwrap(),
+        )
+    } else {
+        (50, 70, 4, 4, 1, 1337)
+        // (13, 15, 2, 4, 3, 1337)
+    };
+    if debug {
+        println!(
+            "qubits: {}, depth: {}, min_weight: {}, max_weight: {}, seed: {}",
+            qs, depth, min_weight, max_weight, seed
+        );
+    }
     let c = Circuit::random_pauli_gadget()
         .qubits(qs)
         .depth(depth)
@@ -61,13 +71,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut g: Graph = c.to_graph();
     let tcount = g.tcount();
-    if debug { println!("g has T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has T-count: {}", g.tcount());
+    }
 
     let time_all = Instant::now();
     quizx::simplify::full_simp(&mut g);
-    if debug { println!("g has reduced T-count: {}", g.tcount()); }
-
+    if debug {
+        println!("g has reduced T-count: {}", g.tcount());
+    }
 
     let mut tcounts = vec![];
     let mut terms = 0;
@@ -83,9 +95,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // let time_single = Instant::now();
         // let mut terms_single = 0;
 
-        let effect: Vec<_> = (0..qs).map(|_| {
-            if rng.gen_bool(0.5) { BasisElem::Z0 } else { BasisElem::Z1 }
-        }).collect();
+        let effect: Vec<_> = (0..qs)
+            .map(|_| {
+                if rng.gen_bool(0.5) {
+                    BasisElem::Z0
+                } else {
+                    BasisElem::Z1
+                }
+            })
+            .collect();
 
         let mut h = g.clone();
         h.plug_outputs(&effect);
@@ -106,15 +124,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         terms += d.nterms;
 
         if debug {
-            println!("terms = {}, P = {}, re(P) ~ {}", d.nterms, prob, prob.float_value().re);
+            println!(
+                "terms = {}, P = {}, re(P) ~ {}",
+                d.nterms,
+                prob,
+                prob.float_value().re
+            );
         }
-
 
         time += time_all.elapsed();
 
         // for small numbers of qubits, it is feasible to check the final probablility
-        success = success &&
-            if qs <= 15 {
+        success = success
+            && if qs <= 15 {
                 print!("Checking tensor...");
                 io::stdout().flush().unwrap();
                 let mut check: Graph = c.to_graph();
@@ -134,21 +156,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 true
             };
 
-
         if debug {
-            println!("Circuit with {} qubits and T-count {} simulated in {:.2?}", qs, tcount, time);
+            println!(
+                "Circuit with {} qubits and T-count {} simulated in {:.2?}",
+                qs, tcount, time
+            );
         }
     }
 
     let naive: f64 = (nsamples as f64) * (qs as f64) * terms_for_tcount(2 * tcount);
     let no_simp: f64 = tcounts.iter().map(|&t| terms_for_tcount(t)).sum();
-    println!("Got {} terms across all samples ({:+e} naive)", terms, naive);
+    println!(
+        "Got {} terms across all samples ({:+e} naive)",
+        terms, naive
+    );
 
     let data = format!("\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{}\",\"{:+e}\",\"{:+e}\"\n",
                        qs, depth, tcount, min_weight, max_weight, nsamples, seed, terms, time.as_millis(), tcounts.iter().format(","), no_simp, naive);
     if success {
         print!("OK {}", data);
-        fs::write(&format!("pauli_gadget_{}_{}_{}_{}_{}_{}", qs, depth, min_weight, max_weight, nsamples, seed), data).expect("Unable to write file");
+        fs::write(
+            &format!(
+                "pauli_gadget_{}_{}_{}_{}_{}_{}",
+                qs, depth, min_weight, max_weight, nsamples, seed
+            ),
+            data,
+        )
+        .expect("Unable to write file");
     } else {
         print!("FAILED {}", data);
     }

--- a/quizx/src/bin/read_circuits.rs
+++ b/quizx/src/bin/read_circuits.rs
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Instant;
 use quizx::circuit::*;
 use std::fs;
+use std::time::Instant;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     for e in fs::read_dir("../../circuits")? {

--- a/quizx/src/bin/scratch.rs
+++ b/quizx/src/bin/scratch.rs
@@ -14,13 +14,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Instant;
 use quizx::circuit::*;
 use quizx::graph::*;
+use std::time::Instant;
 // use quizx::tensor::*;
 // use quizx::scalar::*;
-use quizx::vec_graph::Graph;
 use quizx::decompose::Decomposer;
+use quizx::vec_graph::Graph;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let qs = 40;
@@ -41,16 +41,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let time = Instant::now();
     let mut d = Decomposer::new(&g);
-    d.random_t(true)
-     .with_full_simp();
+    d.random_t(true).with_full_simp();
     let mut max = d.max_terms();
     let mut best_d = d.clone();
 
     for _ in 0..100 {
         let mut d1 = d.clone();
-        d1.decomp_top()
-          .random_t(false)
-          .decomp_until_depth(3);
+        d1.decomp_top().random_t(false).decomp_until_depth(3);
         if d1.max_terms() < max {
             max = d1.max_terms();
             println!("lower max: {}", max);
@@ -61,7 +58,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     d = best_d;
     d.decomp_all();
     println!("Finished in {:.2?}", time.elapsed());
-    println!("got {} terms for T-count {} (naive {} terms)", d.nterms, g.tcount(), max);
+    println!(
+        "got {} terms for T-count {} (naive {} terms)",
+        d.nterms,
+        g.tcount(),
+        max
+    );
 
     // let t = g.to_tensor4();
     // println!("{:?}", t.first().unwrap());

--- a/quizx/src/bin/simp_and_extract.rs
+++ b/quizx/src/bin/simp_and_extract.rs
@@ -16,10 +16,10 @@
 
 // use std::time::Instant;
 use quizx::circuit::*;
-use quizx::vec_graph::*;
-use quizx::simplify::*;
 use quizx::extract::*;
+use quizx::simplify::*;
 use quizx::tensor::*;
+use quizx::vec_graph::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let c = Circuit::from_file("../../../circuits/mod5_4.qasm")?;
@@ -53,11 +53,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 println!("Tensors don't match. \n{}\n\n{}", c, c1);
             }
-        },
+        }
         Err(ExtractError(msg, _c, _g)) => {
             println!("extract failed: {}", msg);
             println!("{}\n\n{}\n\n{}", msg, _c, _g.to_dot());
-        },
+        }
     }
     Ok(())
 }

--- a/quizx/src/bin/spider_chain.rs
+++ b/quizx/src/bin/spider_chain.rs
@@ -29,7 +29,7 @@ fn main() {
 
     for i in 1..sz {
         g.add_vertex(VType::Z);
-        g.add_edge(i-1, i);
+        g.add_edge(i - 1, i);
     }
 
     println!("Done in {:.2?}", time.elapsed());
@@ -40,8 +40,8 @@ fn main() {
     let time = Instant::now();
 
     loop {
-        match g.find_edge(|v0,v1,_| check_spider_fusion(&g, v0, v1)) {
-            Some((v0,v1,_)) => spider_fusion_unchecked(&mut g, v0, v1),
+        match g.find_edge(|v0, v1, _| check_spider_fusion(&g, v0, v1)) {
+            Some((v0, v1, _)) => spider_fusion_unchecked(&mut g, v0, v1),
             None => break,
         };
     }

--- a/quizx/src/bin/stabrank.rs
+++ b/quizx/src/bin/stabrank.rs
@@ -21,8 +21,8 @@ use quizx::circuit::*;
 use quizx::graph::*;
 // use quizx::scalar::*;
 // use quizx::tensor::*;
-use quizx::vec_graph::Graph;
 use quizx::decompose::Decomposer;
+use quizx::vec_graph::Graph;
 // use rayon::prelude::*;
 // use rand::SeedableRng;
 // use rand::rngs::StdRng;
@@ -41,7 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     g.plug_output(0, BasisElem::Z1);
     g.plug(&g.to_adjoint());
 
-    println!("g has T-count: {}", g.tcount()/2);
+    println!("g has T-count: {}", g.tcount() / 2);
     quizx::simplify::full_simp(&mut g);
     println!("g has reduced T-count: {}", g.tcount());
 
@@ -52,7 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Naive: {} terms", max);
 
     // let mut rng = StdRng::seed_from_u64(1337);
-    
+
     // pre-compute candidates on a single thread to use a fixed seed
     // let n = 1000;
     // println!("Generating {} candidates...", n);
@@ -80,7 +80,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // d.decomp_all();
     println!("Finished in {:.2?}", time.elapsed());
 
-    println!("Got {} terms for T-count {} (naive {} terms)", d.nterms, g.tcount(), max);
+    println!(
+        "Got {} terms for T-count {} (naive {} terms)",
+        d.nterms,
+        g.tcount(),
+        max
+    );
     println!("{:?}", d.scalar);
 
     Ok(())

--- a/quizx/src/bin/test_all.rs
+++ b/quizx/src/bin/test_all.rs
@@ -14,18 +14,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Instant;
-use std::fs;
 use quizx::circuit::*;
-use quizx::vec_graph::*;
-use quizx::simplify::*;
 use quizx::extract::*;
+use quizx::simplify::*;
 use quizx::tensor::*;
+use quizx::vec_graph::*;
+use std::fs;
+use std::time::Instant;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     for e in fs::read_dir("../circuits/small")? {
         if let Some(f) = e?.path().to_str() {
-
             let time = Instant::now();
             println!("{}", f);
             let c = Circuit::from_file(f).expect(&format!("circuit failed to parse: {}", f));
@@ -40,7 +39,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             println!("Extracting circuit...");
             let time = Instant::now();
-            let result = g.extractor()
+            let result = g
+                .extractor()
                 .gflow()
                 // .up_to_perm()
                 .extract();
@@ -62,13 +62,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     } else {
                         println!("Checked successfully in {:.2?}", time.elapsed());
                     }
-                },
+                }
                 Err(ExtractError(msg, _c, _g)) => {
                     println!("extract failed: {}", msg);
                     // println!("{}\n\n{}\n\n{}", msg, _c, _g.to_dot());
-                },
+                }
             }
-
         }
     }
 

--- a/quizx/src/bin/test_one.rs
+++ b/quizx/src/bin/test_one.rs
@@ -15,9 +15,9 @@
 // limitations under the License.
 
 use quizx::circuit::*;
+use quizx::extract::*;
 use quizx::hash_graph::*;
 use quizx::simplify::*;
-use quizx::extract::*;
 use std::time::Instant;
 use std::{thread, time};
 
@@ -53,7 +53,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Extracting circuit...");
     let time = Instant::now();
-    let result = g.extractor()
+    let result = g
+        .extractor()
         .gflow()
         // .up_to_perm()
         .extract();
@@ -62,13 +63,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(_c1) => {
             println!("Done in {:.2?}", time.elapsed());
             println!("extracted ok");
-        },
+        }
         Err(ExtractError(msg, _c, _g)) => {
             println!("extract failed: {}", msg);
             // println!("\n\n{}", _g.to_dot());
-        },
+        }
     }
-
 
     thread::sleep(time::Duration::from_millis(100));
     Ok(())

--- a/quizx/src/decompose.rs
+++ b/quizx/src/decompose.rs
@@ -14,14 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num::Rational;
-use std::collections::VecDeque;
-use rand::{thread_rng, Rng};
-use rayon::prelude::*;
 use crate::graph::*;
 use crate::scalar::*;
+use num::Rational;
+use rand::{thread_rng, Rng};
+use rayon::prelude::*;
+use std::collections::VecDeque;
 
-#[derive(Copy,Clone,PartialEq,Eq,Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum SimpFunc {
     FullSimp,
     CliffordSimp,
@@ -32,7 +32,7 @@ use SimpFunc::*;
 /// Store the (partial) decomposition of a graph into stabilisers
 #[derive(Clone)]
 pub struct Decomposer<G: GraphLike> {
-    pub stack: VecDeque<(usize,G)>,
+    pub stack: VecDeque<(usize, G)>,
     pub done: Vec<G>,
     pub scalar: ScalarN,
     pub nterms: usize,
@@ -52,7 +52,9 @@ pub fn terms_for_tcount(tcount: usize) -> f64 {
     let mut count = 7f64.powi(t / 6i32);
     t = t % 6;
     count *= 2f64.powi(t / 2i32);
-    if t % 2 == 1 { count *= 2.0; }
+    if t % 2 == 1 {
+        count *= 2.0;
+    }
     return count;
 }
 
@@ -84,11 +86,11 @@ impl<'a, G: GraphLike> Decomposer<G> {
     pub fn split(mut self) -> Vec<Decomposer<G>> {
         let mut ds = vec![];
         while self.stack.len() > 1 {
-            let (_,g) = self.stack.pop_front().unwrap();
+            let (_, g) = self.stack.pop_front().unwrap();
             let mut d1 = Decomposer::new(&g);
             d1.save(self.save)
-              .random_t(self.random_t)
-              .with_simp(self.simp_func);
+                .random_t(self.random_t)
+                .with_simp(self.simp_func);
             ds.push(d1);
         }
         ds.push(self);
@@ -118,8 +120,12 @@ impl<'a, G: GraphLike> Decomposer<G> {
         self
     }
 
-    pub fn with_full_simp(&mut self) -> &mut Self { self.with_simp(FullSimp) }
-    pub fn with_clifford_simp(&mut self) -> &mut Self { self.with_simp(CliffordSimp) }
+    pub fn with_full_simp(&mut self) -> &mut Self {
+        self.with_simp(FullSimp)
+    }
+    pub fn with_clifford_simp(&mut self) -> &mut Self {
+        self.with_simp(CliffordSimp)
+    }
 
     pub fn random_t(&mut self, b: bool) -> &mut Self {
         self.random_t = b;
@@ -139,13 +145,12 @@ impl<'a, G: GraphLike> Decomposer<G> {
     /// Computes `terms_for_tcount` for every graph on the stack
     pub fn max_terms(&self) -> f64 {
         let mut n = 0.0;
-        for (_,g) in &self.stack {
+        for (_, g) in &self.stack {
             n += terms_for_tcount(g.tcount());
         }
 
         n
     }
-
 
     pub fn pop_graph(&mut self) -> G {
         let (_, g) = self.stack.pop_back().unwrap();
@@ -157,27 +162,32 @@ impl<'a, G: GraphLike> Decomposer<G> {
     pub fn decomp_top(&mut self) -> &mut Self {
         let (depth, g) = self.stack.pop_back().unwrap();
         if self.use_cats {
-            let cat_nodes = Decomposer::cat_ts(&g);//gadget_ts(&g);
-            //println!("{:?}", gadget_nodes);
-            //let nts = cat_nodes.iter().fold(0, |acc, &x| if g.phase(x).denom() == &4 { acc + 1 } else { acc });
+            let cat_nodes = Decomposer::cat_ts(&g); //gadget_ts(&g);
+                                                    //println!("{:?}", gadget_nodes);
+                                                    //let nts = cat_nodes.iter().fold(0, |acc, &x| if g.phase(x).denom() == &4 { acc + 1 } else { acc });
             if cat_nodes.len() > 0 {
                 // println!("using cat!");
-                return self.push_cat_decomp(depth+1, &g, &cat_nodes)                
+                return self.push_cat_decomp(depth + 1, &g, &cat_nodes);
             }
             let ts = Decomposer::first_ts(&g);
-            if ts.len()>=5 {
-                return self.push_magic5_from_cat_decomp(depth+1, &g, &ts[..5])
+            if ts.len() >= 5 {
+                return self.push_magic5_from_cat_decomp(depth + 1, &g, &ts[..5]);
             }
         }
-        let ts = if self.random_t { Decomposer::random_ts(&g, &mut thread_rng()) }
-                 else { Decomposer::first_ts(&g) };
+        let ts = if self.random_t {
+            Decomposer::random_ts(&g, &mut thread_rng())
+        } else {
+            Decomposer::first_ts(&g)
+        };
         self.decomp_ts(depth, g, &ts);
         self
     }
 
     /// Decompose until there are no T gates left
     pub fn decomp_all(&mut self) -> &mut Self {
-        while self.stack.len() > 0 { self.decomp_top(); }
+        while self.stack.len() > 0 {
+            self.decomp_top();
+        }
         self
     }
 
@@ -187,20 +197,29 @@ impl<'a, G: GraphLike> Decomposer<G> {
             // pop from the bottom of the stack to work breadth-first
             let (d, g) = self.stack.pop_front().unwrap();
             if d >= depth {
-                self.stack.push_front((d,g));
+                self.stack.push_front((d, g));
                 break;
             } else {
                 if self.use_cats {
-                    let cat_nodes = Decomposer::cat_ts(&g);//gadget_ts(&g);
-                    //println!("{:?}", gadget_nodes);
-                    let nts = cat_nodes.iter().fold(0, |acc, &x| if g.phase(x).denom() == &4 { acc + 1 } else { acc });
+                    let cat_nodes = Decomposer::cat_ts(&g); //gadget_ts(&g);
+                                                            //println!("{:?}", gadget_nodes);
+                    let nts = cat_nodes.iter().fold(0, |acc, &x| {
+                        if g.phase(x).denom() == &4 {
+                            acc + 1
+                        } else {
+                            acc
+                        }
+                    });
                     if nts > 2 {
                         // println!("using cat!");
-                        return self.push_cat_decomp(depth+1, &g, &cat_nodes)                
+                        return self.push_cat_decomp(depth + 1, &g, &cat_nodes);
                     }
                 }
-                let ts = if self.random_t { Decomposer::random_ts(&g, &mut thread_rng()) }
-                         else { Decomposer::first_ts(&g) };
+                let ts = if self.random_t {
+                    Decomposer::random_ts(&g, &mut thread_rng())
+                } else {
+                    Decomposer::first_ts(&g)
+                };
                 self.decomp_ts(d, g, &ts);
             }
         }
@@ -211,16 +230,24 @@ impl<'a, G: GraphLike> Decomposer<G> {
     pub fn decomp_parallel(mut self, depth: usize) -> Self {
         self.decomp_until_depth(depth);
         let ds = self.split();
-        Decomposer::merge(ds.into_par_iter().map(|mut d| {
-            d.decomp_all(); d
-        }).collect())
+        Decomposer::merge(
+            ds.into_par_iter()
+                .map(|mut d| {
+                    d.decomp_all();
+                    d
+                })
+                .collect(),
+        )
     }
 
     pub fn decomp_ts(&mut self, depth: usize, g: G, ts: &[usize]) {
-        if ts.len() == 6 { self.push_bss_decomp(depth+1, &g, ts); }
-        else if ts.len() >= 2 { self.push_sym_decomp(depth+1, &g, &ts[0..2]); }
-        else if ts.len() > 0 { self.push_single_decomp(depth+1, &g, ts); }
-        else {
+        if ts.len() == 6 {
+            self.push_bss_decomp(depth + 1, &g, ts);
+        } else if ts.len() >= 2 {
+            self.push_sym_decomp(depth + 1, &g, &ts[0..2]);
+        } else if ts.len() > 0 {
+            self.push_single_decomp(depth + 1, &g, ts);
+        } else {
             // crate::simplify::full_simp(&mut g);
             self.scalar = &self.scalar + g.scalar();
             self.nterms += 1;
@@ -229,7 +256,9 @@ impl<'a, G: GraphLike> Decomposer<G> {
                 println!("WARNING: graph was not fully reduced");
                 // println!("{}", g.to_dot());
             }
-            if self.save { self.done.push(g); }
+            if self.save {
+                self.done.push(g);
+            }
         }
     }
 
@@ -238,8 +267,12 @@ impl<'a, G: GraphLike> Decomposer<G> {
         let mut t = vec![];
 
         for v in g.vertices() {
-            if *g.phase(v).denom() == 4 { t.push(v); }
-            if t.len() == 6 { break; }
+            if *g.phase(v).denom() == 4 {
+                t.push(v);
+            }
+            if t.len() == 6 {
+                break;
+            }
         }
 
         t
@@ -262,34 +295,54 @@ impl<'a, G: GraphLike> Decomposer<G> {
     /// The fist vertex in the result is the Clifford spider
     pub fn cat_ts(g: &G) -> Vec<V> {
         // the graph g is supposed to be completely simplified
-        let prefered_order = [4,6,5,3];
+        let prefered_order = [4, 6, 5, 3];
         let mut res = vec![];
         let mut index = None;
         for v in g.vertices() {
-            if g.phase(v).denom() == &1{
+            if g.phase(v).denom() == &1 {
                 let mut neigh = g.neighbor_vec(v);
                 if neigh.len() <= 6 {
                     match prefered_order.iter().position(|&r| r == neigh.len()) {
                         Some(this_ind) => match index {
-                            Some(ind) if this_ind < ind => {res = vec![v]; res.append(&mut neigh); index = Some(this_ind);},
-                            None => {res = vec![v]; res.append(&mut neigh); index = Some(this_ind);},
+                            Some(ind) if this_ind < ind => {
+                                res = vec![v];
+                                res.append(&mut neigh);
+                                index = Some(this_ind);
+                            }
+                            None => {
+                                res = vec![v];
+                                res.append(&mut neigh);
+                                index = Some(this_ind);
+                            }
                             _ => (),
                         },
                         _ => (),
                     }
-                    if index == Some(0){break;}
+                    if index == Some(0) {
+                        break;
+                    }
                 }
             }
         }
         res
     }
 
-    fn push_decomp(&mut self, fs: &[fn (&G, &[V]) -> G], depth: usize, g: &G, verts: &[V]) -> &mut Self {
+    fn push_decomp(
+        &mut self,
+        fs: &[fn(&G, &[V]) -> G],
+        depth: usize,
+        g: &G,
+        verts: &[V],
+    ) -> &mut Self {
         for f in fs {
             let mut g = f(g, verts);
             match self.simp_func {
-                FullSimp => { crate::simplify::full_simp(&mut g); },
-                CliffordSimp => { crate::simplify::clifford_simp(&mut g); },
+                FullSimp => {
+                    crate::simplify::full_simp(&mut g);
+                }
+                CliffordSimp => {
+                    crate::simplify::clifford_simp(&mut g);
+                }
                 _ => {}
             }
 
@@ -313,97 +366,121 @@ impl<'a, G: GraphLike> Decomposer<G> {
     /// equation (11) itself.
     ///
     fn push_bss_decomp(&mut self, depth: usize, g: &G, verts: &[V]) -> &mut Self {
-        self.push_decomp(&[
-            Decomposer::replace_b60,
-            Decomposer::replace_b66,
-            Decomposer::replace_e6,
-            Decomposer::replace_o6,
-            Decomposer::replace_k6,
-            Decomposer::replace_phi1,
-            Decomposer::replace_phi2,
-        ], depth, g, verts)
+        self.push_decomp(
+            &[
+                Decomposer::replace_b60,
+                Decomposer::replace_b66,
+                Decomposer::replace_e6,
+                Decomposer::replace_o6,
+                Decomposer::replace_k6,
+                Decomposer::replace_phi1,
+                Decomposer::replace_phi2,
+            ],
+            depth,
+            g,
+            verts,
+        )
     }
 
     /// Perform a decomposition of 2 T gates in the symmetric 2-qubit
     /// space spanned by stabilisers
     fn push_sym_decomp(&mut self, depth: usize, g: &G, verts: &[V]) -> &mut Self {
-        self.push_decomp(&[
-            Decomposer::replace_bell_s,
-            Decomposer::replace_epr,
-        ], depth, g, verts)
+        self.push_decomp(
+            &[Decomposer::replace_bell_s, Decomposer::replace_epr],
+            depth,
+            g,
+            verts,
+        )
     }
 
     /// Replace a single T gate with its decomposition
     fn push_single_decomp(&mut self, depth: usize, g: &G, verts: &[V]) -> &mut Self {
-        self.push_decomp(&[
-            Decomposer::replace_t0,
-            Decomposer::replace_t1,
-        ], depth, g, verts)
+        self.push_decomp(
+            &[Decomposer::replace_t0, Decomposer::replace_t1],
+            depth,
+            g,
+            verts,
+        )
     }
 
     /// Perform a decomposition of 5 T-spiders, with one remaining
     fn push_magic5_from_cat_decomp(&mut self, depth: usize, g: &G, verts: &[V]) -> &mut Self {
         //println!("magic5");
-        self.push_decomp(&[
-            Decomposer::replace_magic5_0,
-            Decomposer::replace_magic5_1,
-            Decomposer::replace_magic5_2,
-        ], depth, &g, &verts)
+        self.push_decomp(
+            &[
+                Decomposer::replace_magic5_0,
+                Decomposer::replace_magic5_1,
+                Decomposer::replace_magic5_2,
+            ],
+            depth,
+            &g,
+            &verts,
+        )
     }
 
     /// Perform a decomposition of cat states
     fn push_cat_decomp(&mut self, depth: usize, g: &G, verts: &[V]) -> &mut Self {
         // verts[0] is a 0- or pi-spider, linked to all and only to vs in verts[1..] which are T-spiders
-        let mut g = g.clone(); // that is annoying ... 
+        let mut g = g.clone(); // that is annoying ...
         let mut verts = Vec::from(verts);
         if g.phase(verts[0]).numer() == &1 {
-            g.set_phase(verts[0], Rational::new(0,1));
+            g.set_phase(verts[0], Rational::new(0, 1));
             let mut neigh = g.neighbor_vec(verts[1]);
             neigh.retain(|&x| x != verts[0]);
-            for &v in &neigh{
-                g.add_to_phase(v, Rational::new(1,1));
+            for &v in &neigh {
+                g.add_to_phase(v, Rational::new(1, 1));
             }
             let tmp = g.phase(verts[1]);
             *g.scalar_mut() *= ScalarN::from_phase(tmp);
-            g.set_phase(verts[1], g.phase(verts[1])*Rational::new(-1,1));
+            g.set_phase(verts[1], g.phase(verts[1]) * Rational::new(-1, 1));
         }
-        if [3,5].contains(&verts[1..].len()) {
+        if [3, 5].contains(&verts[1..].len()) {
             let w = g.add_vertex(VType::Z);
             let v = g.add_vertex(VType::Z);
             g.add_edge_with_type(v, w, EType::H);
             g.add_edge_with_type(v, verts[0], EType::H);
-            verts.push(v);     
+            verts.push(v);
         }
         if verts[1..].len() == 6 {
-            self.push_decomp(&[
-                Decomposer::replace_cat6_0,
-                Decomposer::replace_cat6_1,
-                Decomposer::replace_cat6_2,
-            ], depth, &g, &verts)
-        }else if verts[1..].len() == 4 {
-            self.push_decomp(&[
-                Decomposer::replace_cat4_0,
-                Decomposer::replace_cat4_1,
-            ], depth, &g, &verts)
-        }else { println!("this shouldn't be printed"); self }
+            self.push_decomp(
+                &[
+                    Decomposer::replace_cat6_0,
+                    Decomposer::replace_cat6_1,
+                    Decomposer::replace_cat6_2,
+                ],
+                depth,
+                &g,
+                &verts,
+            )
+        } else if verts[1..].len() == 4 {
+            self.push_decomp(
+                &[Decomposer::replace_cat4_0, Decomposer::replace_cat4_1],
+                depth,
+                &g,
+                &verts,
+            )
+        } else {
+            println!("this shouldn't be printed");
+            self
+        }
     }
 
     fn replace_cat6_0(g: &G, verts: &[V]) -> G {
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, 0, 0]);    
+        *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, 0, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
             g.set_edge_type(v, verts[0], EType::N);
         }
-        g.set_phase(verts[0], Rational::new(-1,2));
+        g.set_phase(verts[0], Rational::new(-1, 2));
         g
     }
 
     fn replace_cat6_1(g: &G, verts: &[V]) -> G {
-        let mut g = g.clone();  
-        *g.scalar_mut() *= ScalarN::Exact(-1, vec![-1, 0, 1, 0]);    
+        let mut g = g.clone();
+        *g.scalar_mut() *= ScalarN::Exact(-1, vec![-1, 0, 1, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
         }
         g
     }
@@ -412,8 +489,8 @@ impl<'a, G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(7, vec![0, -1, 0, 0]);
         for i in 1..verts.len() {
-            g.add_to_phase(verts[i], Rational::new(-1,4));
-            for j in i+1..verts.len() {
+            g.add_to_phase(verts[i], Rational::new(-1, 4));
+            for j in i + 1..verts.len() {
                 g.add_edge_smart(verts[i], verts[j], EType::H);
             }
         }
@@ -422,24 +499,24 @@ impl<'a, G: GraphLike> Decomposer<G> {
 
     fn replace_magic5_0(g: &G, verts: &[V]) -> G {
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::Exact(1, vec![1, 0, 0, 0]);    
+        *g.scalar_mut() *= ScalarN::Exact(1, vec![1, 0, 0, 0]);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
             g.add_edge_smart(v, verts[0], EType::N);
         }
-        g.add_to_phase(verts[0], Rational::new(-3,4));
+        g.add_to_phase(verts[0], Rational::new(-3, 4));
         g
     }
 
     fn replace_magic5_1(g: &G, verts: &[V]) -> G {
-        let mut g = g.clone();  
+        let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(1, vec![-1, 0, 1, 0]);
         let p = g.add_vertex(VType::Z);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
             g.add_edge_with_type(v, p, EType::H);
         }
-        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1,4));
+        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1, 4));
         g.add_edge_with_type(w, p, EType::H);
         g
     }
@@ -448,13 +525,13 @@ impl<'a, G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(9, vec![0, -1, 0, 0]);
         let p = g.add_vertex(VType::Z);
-        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1,4));
+        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1, 4));
         g.add_edge_with_type(p, w, EType::H);
         for i in 0..verts.len() {
-            g.add_to_phase(verts[i], Rational::new(-1,4));
+            g.add_to_phase(verts[i], Rational::new(-1, 4));
             g.add_edge_with_type(verts[i], p, EType::H);
             g.add_edge_with_type(verts[i], w, EType::H);
-            for j in i+1..verts.len() {
+            for j in i + 1..verts.len() {
                 g.add_edge_smart(verts[i], verts[j], EType::H);
             }
         }
@@ -463,22 +540,22 @@ impl<'a, G: GraphLike> Decomposer<G> {
 
     fn replace_cat4_0(g: &G, verts: &[V]) -> G {
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::Exact(0, vec![0, 0, 1, 0]);    
+        *g.scalar_mut() *= ScalarN::Exact(0, vec![0, 0, 1, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
         }
         g
     }
 
     fn replace_cat4_1(g: &G, verts: &[V]) -> G {
         // same as replace_cat6_0, only with a different scalar
-        let mut g = g.clone();  
-        *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, -1, 0]);    
+        let mut g = g.clone();
+        *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, -1, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
             g.set_edge_type(v, verts[0], EType::N);
         }
-        g.set_phase(verts[0], Rational::new(-1,2));
+        g.set_phase(verts[0], Rational::new(-1, 2));
         g
     }
 
@@ -486,7 +563,9 @@ impl<'a, G: GraphLike> Decomposer<G> {
         // println!("replace_b60");
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-2, vec![-1, 0, 1, 1]);
-        for &v in &verts[0..6] { g.add_to_phase(v, Rational::new(-1,4)); }
+        for &v in &verts[0..6] {
+            g.add_to_phase(v, Rational::new(-1, 4));
+        }
         g
     }
 
@@ -494,7 +573,9 @@ impl<'a, G: GraphLike> Decomposer<G> {
         // println!("replace_b66");
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-2, vec![-1, 0, 1, -1]);
-        for &v in verts { g.add_to_phase(v, Rational::new(3,4)); }
+        for &v in verts {
+            g.add_to_phase(v, Rational::new(3, 4));
+        }
         g
     }
 
@@ -505,7 +586,7 @@ impl<'a, G: GraphLike> Decomposer<G> {
 
         let w = g.add_vertex_with_phase(VType::Z, Rational::one());
         for &v in verts {
-            g.add_to_phase(v, Rational::new(1,4));
+            g.add_to_phase(v, Rational::new(1, 4));
             g.add_edge_with_type(v, w, EType::H);
         }
 
@@ -519,7 +600,7 @@ impl<'a, G: GraphLike> Decomposer<G> {
 
         let w = g.add_vertex(VType::Z);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(1,4));
+            g.add_to_phase(v, Rational::new(1, 4));
             g.add_edge_with_type(v, w, EType::H);
         }
 
@@ -531,9 +612,9 @@ impl<'a, G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(1, vec![1, 0, 0, 0]);
 
-        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1,2));
+        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1, 2));
         for &v in verts {
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
             g.add_edge_with_type(v, w, EType::N);
         }
 
@@ -551,10 +632,10 @@ impl<'a, G: GraphLike> Decomposer<G> {
             ws.push(w);
             g.add_edge_with_type(verts[i], ws[i], EType::H);
             g.add_edge_with_type(ws[i], verts[5], EType::H);
-            g.add_to_phase(verts[i], Rational::new(-1,4));
+            g.add_to_phase(verts[i], Rational::new(-1, 4));
         }
 
-        g.add_to_phase(verts[5], Rational::new(3,4));
+        g.add_to_phase(verts[5], Rational::new(3, 4));
 
         g.add_edge_with_type(ws[0], ws[2], EType::H);
         g.add_edge_with_type(ws[0], ws[3], EType::H);
@@ -567,21 +648,18 @@ impl<'a, G: GraphLike> Decomposer<G> {
 
     fn replace_phi2(g: &G, verts: &[V]) -> G {
         // print!("replace_phi2 -> ");
-        Decomposer::replace_phi1(g, &vec![
-                                 verts[0],
-                                 verts[1],
-                                 verts[3],
-                                 verts[4],
-                                 verts[5],
-                                 verts[2]])
+        Decomposer::replace_phi1(
+            g,
+            &vec![verts[0], verts[1], verts[3], verts[4], verts[5], verts[2]],
+        )
     }
 
     fn replace_bell_s(g: &G, verts: &[V]) -> G {
         // println!("replace_bell_s");
         let mut g = g.clone();
         g.add_edge_smart(verts[0], verts[1], EType::N);
-        g.add_to_phase(verts[0], Rational::new(-1,4));
-        g.add_to_phase(verts[1], Rational::new(1,4));
+        g.add_to_phase(verts[0], Rational::new(-1, 4));
+        g.add_to_phase(verts[1], Rational::new(1, 4));
 
         g
     }
@@ -589,11 +667,11 @@ impl<'a, G: GraphLike> Decomposer<G> {
     fn replace_epr(g: &G, verts: &[V]) -> G {
         // println!("replace_epr");
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::from_phase(Rational::new(1,4));
+        *g.scalar_mut() *= ScalarN::from_phase(Rational::new(1, 4));
         let w = g.add_vertex_with_phase(VType::Z, Rational::one());
         for &v in verts {
             g.add_edge_with_type(v, w, EType::H);
-            g.add_to_phase(v, Rational::new(-1,4));
+            g.add_to_phase(v, Rational::new(-1, 4));
         }
 
         g
@@ -602,20 +680,20 @@ impl<'a, G: GraphLike> Decomposer<G> {
     fn replace_t0(g: &G, verts: &[V]) -> G {
         // println!("replace_t0");
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::Exact(-1, vec![0,1,0,-1]);
+        *g.scalar_mut() *= ScalarN::Exact(-1, vec![0, 1, 0, -1]);
         let w = g.add_vertex(VType::Z);
         g.add_edge_with_type(verts[0], w, EType::H);
-        g.add_to_phase(verts[0], Rational::new(-1,4));
+        g.add_to_phase(verts[0], Rational::new(-1, 4));
         g
     }
 
     fn replace_t1(g: &G, verts: &[V]) -> G {
         // println!("replace_t1");
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::Exact(-1, vec![1,0,1,0]);
+        *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, 1, 0]);
         let w = g.add_vertex_with_phase(VType::Z, Rational::one());
         g.add_edge_with_type(verts[0], w, EType::H);
-        g.add_to_phase(verts[0], Rational::new(-1,4));
+        g.add_to_phase(verts[0], Rational::new(-1, 4));
         g
     }
 }
@@ -660,18 +738,18 @@ mod tests {
     #[test]
     fn single_scalars() {
         let s0 = ScalarN::sqrt2_pow(-1);
-        let s1 = ScalarN::from_phase(Rational::new(1,4)) * &s0;
+        let s1 = ScalarN::from_phase(Rational::new(1, 4)) * &s0;
         println!("s0 = {:?}\ns1 = {:?}", s0, s1);
-        assert_eq!(s0, ScalarN::Exact(-1, vec![0,1,0,-1]));
-        assert_eq!(s1, ScalarN::Exact(-1, vec![1,0,1,0]));
+        assert_eq!(s0, ScalarN::Exact(-1, vec![0, 1, 0, -1]));
+        assert_eq!(s1, ScalarN::Exact(-1, vec![1, 0, 1, 0]));
     }
 
     #[test]
     fn single() {
         let mut g = Graph::new();
-        let v = g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+        let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
         let w = g.add_vertex(VType::B);
-        g.add_edge(v,w);
+        g.add_edge(v, w);
         g.set_outputs(vec![w]);
 
         let mut d = Decomposer::new(&g);
@@ -680,7 +758,9 @@ mod tests {
 
         let t = g.to_tensor4();
         let mut tsum = Tensor4::zeros(vec![2]);
-        for (_,h) in &d.stack { tsum = tsum + h.to_tensor4(); }
+        for (_, h) in &d.stack {
+            tsum = tsum + h.to_tensor4();
+        }
         assert_eq!(t, tsum);
     }
 
@@ -689,7 +769,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..2 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -702,7 +782,9 @@ mod tests {
 
         let t = g.to_tensor4();
         let mut tsum = Tensor4::zeros(vec![2; 2]);
-        for (_,h) in &d.stack { tsum = tsum + h.to_tensor4(); }
+        for (_, h) in &d.stack {
+            tsum = tsum + h.to_tensor4();
+        }
         assert_eq!(t, tsum);
     }
 
@@ -711,7 +793,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..6 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -724,7 +806,9 @@ mod tests {
 
         let t = g.to_tensor4();
         let mut tsum = Tensor4::zeros(vec![2; 6]);
-        for (_,h) in &d.stack { tsum = tsum + h.to_tensor4(); }
+        for (_, h) in &d.stack {
+            tsum = tsum + h.to_tensor4();
+        }
         assert_eq!(t, tsum);
     }
 
@@ -733,7 +817,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..9 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -742,10 +826,12 @@ mod tests {
 
         let mut d = Decomposer::new(&g);
         d.save(true);
-        assert_eq!(d.max_terms(), 7.0*2.0*2.0);
-        while d.stack.len() > 0 { d.decomp_top(); }
+        assert_eq!(d.max_terms(), 7.0 * 2.0 * 2.0);
+        while d.stack.len() > 0 {
+            d.decomp_top();
+        }
 
-        assert_eq!(d.done.len(), 7*2*2);
+        assert_eq!(d.done.len(), 7 * 2 * 2);
 
         // thorough but SLOW
         // let t = g.to_tensor4();
@@ -758,7 +844,7 @@ mod tests {
     fn mixed_sc() {
         let mut g = Graph::new();
         for i in 0..11 {
-            g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+            g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
 
             for j in 0..i {
                 g.add_edge_with_type(i, j, EType::H);
@@ -766,7 +852,6 @@ mod tests {
             // let w = g.add_vertex(VType::Z);
             // g.add_edge(v, w);
         }
-
 
         let mut d = Decomposer::new(&g);
         d.with_full_simp();
@@ -778,13 +863,12 @@ mod tests {
         assert_eq!(Scalar::from_scalar(&sc), d.scalar);
     }
 
-
     #[test]
     fn all_and_depth() {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..9 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -794,11 +878,11 @@ mod tests {
         let mut d = Decomposer::new(&g);
         d.with_full_simp();
         d.save(true).decomp_all();
-        assert_eq!(d.done.len(), 7*2*2);
+        assert_eq!(d.done.len(), 7 * 2 * 2);
         let mut d = Decomposer::new(&g);
         d.with_full_simp();
         d.decomp_until_depth(2);
-        assert_eq!(d.stack.len(), 7*2);
+        assert_eq!(d.stack.len(), 7 * 2);
     }
 
     #[test]
@@ -806,7 +890,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..9 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1,4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -814,9 +898,7 @@ mod tests {
         g.set_outputs(outs);
 
         let mut d = Decomposer::new(&g);
-        d.with_full_simp()
-         .save(true)
-         .decomp_all();
-        assert_eq!(d.done.len(), 7*2*2);
+        d.with_full_simp().save(true).decomp_all();
+        assert_eq!(d.done.len(), 7 * 2 * 2);
     }
 }

--- a/quizx/src/generate.rs
+++ b/quizx/src/generate.rs
@@ -18,9 +18,9 @@ use std::mem;
 
 use crate::circuit::*;
 use crate::gate::*;
-use rand::{SeedableRng, Rng};
-use rand::rngs::StdRng;
 use num::Rational;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 pub struct RandomCircuitBuilder {
     pub rng: StdRng,
@@ -52,14 +52,14 @@ pub struct RandomPauliGadgetCircuitBuilder {
 impl Circuit {
     pub fn random() -> RandomCircuitBuilder {
         RandomCircuitBuilder {
-            rng:    StdRng::from_entropy(),
+            rng: StdRng::from_entropy(),
             qubits: 0,
-            depth:  0,
+            depth: 0,
             p_cnot: 0.0,
-            p_cz:   0.0,
-            p_h:    0.0,
-            p_s:    0.0,
-            p_t:    0.0,
+            p_cz: 0.0,
+            p_h: 0.0,
+            p_s: 0.0,
+            p_t: 0.0,
         }
     }
 
@@ -74,25 +74,49 @@ impl Circuit {
 
     pub fn random_pauli_gadget() -> RandomPauliGadgetCircuitBuilder {
         RandomPauliGadgetCircuitBuilder {
-            rng:         StdRng::from_entropy(),
-            qubits:      40,
-            depth:       10,
-            min_weight:  2,
-            max_weight:  4,
+            rng: StdRng::from_entropy(),
+            qubits: 40,
+            depth: 10,
+            min_weight: 2,
+            max_weight: 4,
             phase_denom: 4,
         }
     }
 }
 
 impl RandomCircuitBuilder {
-    pub fn seed(&mut self, seed: u64) -> &mut Self { self.rng = StdRng::seed_from_u64(seed); self }
-    pub fn qubits(&mut self, qubits: usize) -> &mut Self { self.qubits = qubits; self }
-    pub fn depth(&mut self, depth: usize) -> &mut Self { self.depth = depth; self }
-    pub fn p_cnot(&mut self, p_cnot: f32) -> &mut Self { self.p_cnot = p_cnot; self }
-    pub fn p_cz(&mut self, p_cz: f32) -> &mut Self { self.p_cz = p_cz; self }
-    pub fn p_h(&mut self, p_h: f32) -> &mut Self { self.p_h = p_h; self }
-    pub fn p_s(&mut self, p_s: f32) -> &mut Self { self.p_s = p_s; self }
-    pub fn p_t(&mut self, p_t: f32) -> &mut Self { self.p_t = p_t; self }
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.rng = StdRng::seed_from_u64(seed);
+        self
+    }
+    pub fn qubits(&mut self, qubits: usize) -> &mut Self {
+        self.qubits = qubits;
+        self
+    }
+    pub fn depth(&mut self, depth: usize) -> &mut Self {
+        self.depth = depth;
+        self
+    }
+    pub fn p_cnot(&mut self, p_cnot: f32) -> &mut Self {
+        self.p_cnot = p_cnot;
+        self
+    }
+    pub fn p_cz(&mut self, p_cz: f32) -> &mut Self {
+        self.p_cz = p_cz;
+        self
+    }
+    pub fn p_h(&mut self, p_h: f32) -> &mut Self {
+        self.p_h = p_h;
+        self
+    }
+    pub fn p_s(&mut self, p_s: f32) -> &mut Self {
+        self.p_s = p_s;
+        self
+    }
+    pub fn p_t(&mut self, p_t: f32) -> &mut Self {
+        self.p_t = p_t;
+        self
+    }
 
     /// Distribute the remaining probability evenly among Clifford (CNOT, H, S) gates
     pub fn with_cliffords(&mut self) -> &mut Self {
@@ -127,24 +151,40 @@ impl RandomCircuitBuilder {
             let mut p0 = 0.0;
             let p: f32 = self.rng.gen();
             let q0 = self.rng.gen_range(0..self.qubits);
-            let mut q1 = self.rng.gen_range(0..self.qubits-1);
-            if q1 >= q0 { q1 += 1; }
+            let mut q1 = self.rng.gen_range(0..self.qubits - 1);
+            if q1 >= q0 {
+                q1 += 1;
+            }
 
             p0 += self.p_cnot;
-            if p < p0 { c.push(Gate::new(CNOT, vec![q0,q1])); continue; }
+            if p < p0 {
+                c.push(Gate::new(CNOT, vec![q0, q1]));
+                continue;
+            }
 
             p0 += self.p_cz;
-            if p < p0 { c.push(Gate::new(CZ, vec![q0,q1])); continue; }
+            if p < p0 {
+                c.push(Gate::new(CZ, vec![q0, q1]));
+                continue;
+            }
 
             p0 += self.p_h;
-            if p < p0 { c.push(Gate::new(HAD, vec![q0])); continue; }
+            if p < p0 {
+                c.push(Gate::new(HAD, vec![q0]));
+                continue;
+            }
 
             p0 += self.p_s;
-            if p < p0 { c.push(Gate::new(S, vec![q0])); continue; }
+            if p < p0 {
+                c.push(Gate::new(S, vec![q0]));
+                continue;
+            }
 
             p0 += self.p_t;
-            if p < p0 { c.push(Gate::new(T, vec![q0])); continue; }
-
+            if p < p0 {
+                c.push(Gate::new(T, vec![q0]));
+                continue;
+            }
         }
 
         c
@@ -152,35 +192,57 @@ impl RandomCircuitBuilder {
 }
 
 impl RandomHiddenShiftCircuitBuilder {
-    pub fn seed(&mut self, seed: u64) -> &mut Self { self.rng = StdRng::seed_from_u64(seed); self }
-    pub fn qubits(&mut self, qubits: usize) -> &mut Self { self.qubits = qubits; self }
-    pub fn clifford_depth(&mut self, clifford_depth: usize) -> &mut Self { self.clifford_depth = clifford_depth; self }
-    pub fn n_ccz(&mut self, n_ccz: usize) -> &mut Self { self.n_ccz = n_ccz; self }
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.rng = StdRng::seed_from_u64(seed);
+        self
+    }
+    pub fn qubits(&mut self, qubits: usize) -> &mut Self {
+        self.qubits = qubits;
+        self
+    }
+    pub fn clifford_depth(&mut self, clifford_depth: usize) -> &mut Self {
+        self.clifford_depth = clifford_depth;
+        self
+    }
+    pub fn n_ccz(&mut self, n_ccz: usize) -> &mut Self {
+        self.n_ccz = n_ccz;
+        self
+    }
 
     fn random_clifford_layer(&mut self, c: &mut Circuit) {
-        let qs = self.qubits/2;
+        let qs = self.qubits / 2;
         for _ in 0..self.clifford_depth {
             let q0 = self.rng.gen_range(0..qs);
 
             if self.rng.gen_bool(0.5) {
                 c.push(Gate::new(Z, vec![q0]));
             } else {
-                let mut q1 = self.rng.gen_range(0..qs-1);
-                if q1 >= q0 { q1 += 1; }
-                c.push(Gate::new(CZ, vec![q0,q1]));
+                let mut q1 = self.rng.gen_range(0..qs - 1);
+                if q1 >= q0 {
+                    q1 += 1;
+                }
+                c.push(Gate::new(CZ, vec![q0, q1]));
             }
         }
     }
 
     fn random_ccz(&mut self, c: &mut Circuit) {
-        let qs = self.qubits/2;
+        let qs = self.qubits / 2;
         let mut q0 = self.rng.gen_range(0..qs);
-        let mut q1 = self.rng.gen_range(0..qs-1);
-        let mut q2 = self.rng.gen_range(0..qs-2);
-        if q1 >= q0 { q1 += 1; } else { mem::swap(&mut q0, &mut q1); }
-        if q2 >= q0 { q2 += 1; }
-        if q2 >= q1 { q2 += 1; }
-        c.push(Gate::new(CCZ, vec![q0,q1,q2]));
+        let mut q1 = self.rng.gen_range(0..qs - 1);
+        let mut q2 = self.rng.gen_range(0..qs - 2);
+        if q1 >= q0 {
+            q1 += 1;
+        } else {
+            mem::swap(&mut q0, &mut q1);
+        }
+        if q2 >= q0 {
+            q2 += 1;
+        }
+        if q2 >= q1 {
+            q2 += 1;
+        }
+        c.push(Gate::new(CCZ, vec![q0, q1, q2]));
     }
 
     pub fn build(&mut self) -> (Circuit, Vec<u8>) {
@@ -195,13 +257,14 @@ impl RandomHiddenShiftCircuitBuilder {
         self.random_clifford_layer(&mut oraclef);
 
         let mut oracleg = oraclef.clone();
-        oracleg.gates.iter_mut().for_each(|g|
-            g.qs.iter_mut().for_each(|q| *q += self.qubits/2)
-        );
+        oracleg
+            .gates
+            .iter_mut()
+            .for_each(|g| g.qs.iter_mut().for_each(|q| *q += self.qubits / 2));
 
-        for q in 0..self.qubits/2 {
-            oraclef.push(Gate::new(CZ, vec![q,q+(self.qubits/2)]));
-            oracleg.push(Gate::new(CZ, vec![q,q+(self.qubits/2)]));
+        for q in 0..self.qubits / 2 {
+            oraclef.push(Gate::new(CZ, vec![q, q + (self.qubits / 2)]));
+            oracleg.push(Gate::new(CZ, vec![q, q + (self.qubits / 2)]));
         }
 
         let mut shift = vec![];
@@ -216,7 +279,9 @@ impl RandomHiddenShiftCircuitBuilder {
         }
 
         let mut hs = Circuit::new(self.qubits);
-        for q in 0..self.qubits { hs.push(Gate::new(HAD, vec![q])); }
+        for q in 0..self.qubits {
+            hs.push(Gate::new(HAD, vec![q]));
+        }
 
         let mut c = Circuit::new(self.qubits);
         c += &hs;
@@ -230,13 +295,35 @@ impl RandomHiddenShiftCircuitBuilder {
 }
 
 impl RandomPauliGadgetCircuitBuilder {
-    pub fn seed(&mut self, seed: u64) -> &mut Self { self.rng = StdRng::seed_from_u64(seed); self }
-    pub fn qubits(&mut self, qubits: usize) -> &mut Self { self.qubits = qubits; self }
-    pub fn depth(&mut self, depth: usize) -> &mut Self { self.depth = depth; self }
-    pub fn min_weight(&mut self, min_weight: usize) -> &mut Self { self.min_weight = min_weight; self }
-    pub fn max_weight(&mut self, max_weight: usize) -> &mut Self { self.max_weight = max_weight; self }
-    pub fn weight(&mut self, weight: usize) -> &mut Self { self.min_weight = weight; self.max_weight = weight; self }
-    pub fn phase_denom(&mut self, phase_denom: usize) -> &mut Self { self.phase_denom = phase_denom; self }
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.rng = StdRng::seed_from_u64(seed);
+        self
+    }
+    pub fn qubits(&mut self, qubits: usize) -> &mut Self {
+        self.qubits = qubits;
+        self
+    }
+    pub fn depth(&mut self, depth: usize) -> &mut Self {
+        self.depth = depth;
+        self
+    }
+    pub fn min_weight(&mut self, min_weight: usize) -> &mut Self {
+        self.min_weight = min_weight;
+        self
+    }
+    pub fn max_weight(&mut self, max_weight: usize) -> &mut Self {
+        self.max_weight = max_weight;
+        self
+    }
+    pub fn weight(&mut self, weight: usize) -> &mut Self {
+        self.min_weight = weight;
+        self.max_weight = weight;
+        self
+    }
+    pub fn phase_denom(&mut self, phase_denom: usize) -> &mut Self {
+        self.phase_denom = phase_denom;
+        self
+    }
 
     pub fn build(&mut self) -> Circuit {
         let mut c = Circuit::new(self.qubits);
@@ -245,7 +332,9 @@ impl RandomPauliGadgetCircuitBuilder {
         for _ in 0..self.depth {
             // pick a random weight in the provided range, inclusive
             let w = self.rng.gen_range(self.min_weight..=self.max_weight);
-            if w > self.qubits { panic!("Weight larger than total qubits"); }
+            if w > self.qubits {
+                panic!("Weight larger than total qubits");
+            }
 
             // randomly pick w qubits
             let mut all_qs: Vec<_> = (0..self.qubits).collect();
@@ -261,30 +350,35 @@ impl RandomPauliGadgetCircuitBuilder {
             let mut lc = Circuit::new(self.qubits);
             for &q in &qs {
                 match self.rng.gen_range(0..=2) {
-                    1 => { lc.push(Gate::new(HAD, vec![q])) },
+                    1 => lc.push(Gate::new(HAD, vec![q])),
                     2 => {
                         let mut g = Gate::new(XPhase, vec![q]);
-                        g.phase = Rational::new(1,2);
+                        g.phase = Rational::new(1, 2);
                         lc.push(g);
-                    },
-                    _ => {},
+                    }
+                    _ => {}
                 }
             }
 
             // choose random non-clifford (if possible) phase with a fixed denominator
-            let phase_num =
-                if self.phase_denom >= 4 && self.phase_denom % 2 == 0 {
-                    // if the denominator is even, avoid picking rationals equal to 1/2, 1, or 3/2
-                    let mut p = self.rng.gen_range(1..(2*self.phase_denom)-3);
-                    if p >= self.phase_denom/2 { p += 1; }
-                    if p >= self.phase_denom { p += 1; }
-                    if p >= (3*self.phase_denom)/2 { p += 1; }
+            let phase_num = if self.phase_denom >= 4 && self.phase_denom % 2 == 0 {
+                // if the denominator is even, avoid picking rationals equal to 1/2, 1, or 3/2
+                let mut p = self.rng.gen_range(1..(2 * self.phase_denom) - 3);
+                if p >= self.phase_denom / 2 {
+                    p += 1;
+                }
+                if p >= self.phase_denom {
+                    p += 1;
+                }
+                if p >= (3 * self.phase_denom) / 2 {
+                    p += 1;
+                }
 
-                    p
-                } else {
-                    // if the denominator is odd or too small, just choose any non-trivial phase
-                    self.rng.gen_range(1..2*self.phase_denom)
-                };
+                p
+            } else {
+                // if the denominator is odd or too small, just choose any non-trivial phase
+                self.rng.gen_range(1..2 * self.phase_denom)
+            };
 
             let mut g = Gate::new(ParityPhase, qs);
             g.phase = Rational::new(phase_num as isize, self.phase_denom as isize);
@@ -323,9 +417,7 @@ mod tests {
     #[test]
     fn random_seeds() {
         let mut builder = Circuit::random();
-        builder.qubits(5)
-            .depth(20)
-            .uniform();
+        builder.qubits(5).depth(20).uniform();
 
         builder.seed(1337);
         let c1 = builder.build();
@@ -344,7 +436,8 @@ mod tests {
     fn random_all_gates() {
         // this could fail with some (small) probablity, so try some fixed seeds
         for &seed in &[1337, 800, 40104] {
-            let c = Circuit::random().seed(seed)
+            let c = Circuit::random()
+                .seed(seed)
                 .qubits(10)
                 .depth(100)
                 .with_cliffords()
@@ -355,7 +448,8 @@ mod tests {
             assert_ne!(c.num_gates_of_type(S), 0);
             assert_eq!(c.num_gates_of_type(T), 0);
 
-            let c = Circuit::random().seed(seed)
+            let c = Circuit::random()
+                .seed(seed)
                 .qubits(10)
                 .depth(100)
                 .p_t(0.3)
@@ -367,7 +461,8 @@ mod tests {
             assert_ne!(c.num_gates_of_type(S), 0);
             assert_ne!(c.num_gates_of_type(T), 0);
 
-            let c = Circuit::random().seed(seed)
+            let c = Circuit::random()
+                .seed(seed)
                 .qubits(10)
                 .depth(100)
                 .uniform()
@@ -385,14 +480,16 @@ mod tests {
         // this could fail with some (small) probablity, so try some fixed seeds
         for &seed in &[1337, 800, 40104] {
             let q = 40;
-            let c = Circuit::random_hidden_shift().seed(seed)
+            let c = Circuit::random_hidden_shift()
+                .seed(seed)
                 .qubits(q)
                 .clifford_depth(200)
                 .n_ccz(6)
-                .build().0;
+                .build()
+                .0;
             assert_ne!(c.num_gates_of_type(Z), 0);
             assert_ne!(c.num_gates_of_type(CZ), 0);
-            assert_eq!(c.num_gates_of_type(HAD), q*3);
+            assert_eq!(c.num_gates_of_type(HAD), q * 3);
             assert_eq!(c.num_gates_of_type(CCZ), 12);
         }
     }
@@ -401,7 +498,8 @@ mod tests {
     fn random_pauli_gadget() {
         for &seed in &[1337, 800, 40104] {
             let depth = 100;
-            let c = Circuit::random_pauli_gadget().seed(seed)
+            let c = Circuit::random_pauli_gadget()
+                .seed(seed)
                 .qubits(50)
                 .min_weight(4)
                 .max_weight(10)

--- a/quizx/src/hash_graph.rs
+++ b/quizx/src/hash_graph.rs
@@ -16,13 +16,13 @@
 
 pub use crate::graph::*;
 use crate::scalar::*;
-use rustc_hash::FxHashMap;
 use num::rational::Rational;
+use rustc_hash::FxHashMap;
 use std::iter::FromIterator;
 
-pub type VTab<T> = FxHashMap<V,T>;
+pub type VTab<T> = FxHashMap<V, T>;
 
-#[derive(Debug,Clone,PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Graph {
     vdata: VTab<VData>,
     edata: VTab<VTab<EType>>,
@@ -35,28 +35,36 @@ pub struct Graph {
 }
 
 pub struct EdgeIter<'a> {
-    outer: std::collections::hash_map::Iter<'a,V,VTab<EType>>,
-    inner: Option<(V, std::collections::hash_map::Iter<'a,V,EType>)>,
+    outer: std::collections::hash_map::Iter<'a, V, VTab<EType>>,
+    inner: Option<(V, std::collections::hash_map::Iter<'a, V, EType>)>,
 }
 
 impl<'a> Iterator for EdgeIter<'a> {
     /// Iterate over the edges in a graph. An edge is returned as a triple
     /// (s: V, t: V, ety: EType), where we enforce s <= t to avoid double-
     /// counting edges.
-    type Item = (V,V,EType);
+    type Item = (V, V, EType);
 
     fn next(&mut self) -> Option<Self::Item> {
-       match &mut self.inner {
-           Some((s, iter)) =>
-               match iter.next() {
-                   Some((t,ety)) => if *s <= *t { Some((*s,*t,*ety)) } else { self.next() }
-                   None => match self.outer.next() {
-                       Some((k,v)) => { self.inner = Some((*k,v.iter())); self.next() }
-                       None => None
-                   }
-               }
-           None => None
-       }
+        match &mut self.inner {
+            Some((s, iter)) => match iter.next() {
+                Some((t, ety)) => {
+                    if *s <= *t {
+                        Some((*s, *t, *ety))
+                    } else {
+                        self.next()
+                    }
+                }
+                None => match self.outer.next() {
+                    Some((k, v)) => {
+                        self.inner = Some((*k, v.iter()));
+                        self.next()
+                    }
+                    None => None,
+                },
+            },
+            None => None,
+        }
     }
 }
 
@@ -65,9 +73,7 @@ impl Graph {
     /// is used by remove_edge and remove_vertex to make the latter slightly
     /// more efficient.
     fn remove_half_edge(&mut self, s: V, t: V) {
-        self.edata
-            .get_mut(&s)
-            .map(|nhd| nhd.remove(&t));
+        self.edata.get_mut(&s).map(|nhd| nhd.remove(&t));
     }
 }
 
@@ -105,15 +111,32 @@ impl GraphLike for Graph {
         EIter::Hash(self.nume, self.edata.iter(), None)
     }
 
-    fn inputs(&self) -> &Vec<V> { &self.inputs }
-    fn inputs_mut(&mut self) -> &mut Vec<V> { &mut self.inputs }
-    fn set_inputs(&mut self, inputs: Vec<V>) { self.inputs = inputs; }
-    fn outputs(&self) -> &Vec<V> { &self.outputs }
-    fn set_outputs(&mut self, outputs: Vec<V>) { self.outputs = outputs; }
-    fn outputs_mut(&mut self) -> &mut Vec<V> { &mut self.outputs }
+    fn inputs(&self) -> &Vec<V> {
+        &self.inputs
+    }
+    fn inputs_mut(&mut self) -> &mut Vec<V> {
+        &mut self.inputs
+    }
+    fn set_inputs(&mut self, inputs: Vec<V>) {
+        self.inputs = inputs;
+    }
+    fn outputs(&self) -> &Vec<V> {
+        &self.outputs
+    }
+    fn set_outputs(&mut self, outputs: Vec<V>) {
+        self.outputs = outputs;
+    }
+    fn outputs_mut(&mut self) -> &mut Vec<V> {
+        &mut self.outputs
+    }
 
     fn add_vertex(&mut self, ty: VType) -> V {
-        self.add_vertex_with_data(VData { ty, phase: Rational::new(0,1), qubit: 0, row: 0 })
+        self.add_vertex_with_data(VData {
+            ty,
+            phase: Rational::new(0, 1),
+            qubit: 0,
+            row: 0,
+        })
     }
 
     fn add_vertex_with_data(&mut self, d: VData) -> V {
@@ -130,7 +153,7 @@ impl GraphLike for Graph {
 
         for v1 in Vec::from_iter(self.neighbors(v)) {
             self.nume -= 1;
-            self.remove_half_edge(v1,v);
+            self.remove_half_edge(v1, v);
         }
 
         self.vdata.remove(&v);
@@ -140,31 +163,28 @@ impl GraphLike for Graph {
     fn add_edge_with_type(&mut self, s: V, t: V, ety: EType) {
         self.nume += 1;
 
-        self.edata.get_mut(&s)
+        self.edata
+            .get_mut(&s)
             .expect("Source vertex not found")
             .insert(t, ety);
-        self.edata.get_mut(&t)
+        self.edata
+            .get_mut(&t)
             .expect("Target vertex not found")
             .insert(s, ety);
     }
 
-
     fn remove_edge(&mut self, s: V, t: V) {
         self.nume -= 1;
-        self.remove_half_edge(s,t);
-        self.remove_half_edge(t,s);
+        self.remove_half_edge(s, t);
+        self.remove_half_edge(t, s);
     }
 
     fn set_phase(&mut self, v: V, phase: Rational) {
-        self.vdata.get_mut(&v)
-            .expect("Vertex not found")
-            .phase = phase.mod2();
+        self.vdata.get_mut(&v).expect("Vertex not found").phase = phase.mod2();
     }
 
     fn phase(&self, v: V) -> Rational {
-        self.vdata.get(&v)
-            .expect("Vertex not found")
-            .phase
+        self.vdata.get(&v).expect("Vertex not found").phase
     }
 
     fn add_to_phase(&mut self, v: V, phase: Rational) {
@@ -176,100 +196,95 @@ impl GraphLike for Graph {
     }
 
     fn set_vertex_type(&mut self, v: V, ty: VType) {
-        self.vdata.get_mut(&v)
-            .expect("Vertex not found")
-            .ty = ty;
+        self.vdata.get_mut(&v).expect("Vertex not found").ty = ty;
     }
 
     fn vertex_data(&self, v: V) -> VData {
-        *self.vdata.get(&v)
-             .expect("Vertex not found")
+        *self.vdata.get(&v).expect("Vertex not found")
     }
 
     fn vertex_type(&self, v: V) -> VType {
-        self.vdata.get(&v)
-            .expect("Vertex not found")
-            .ty
+        self.vdata.get(&v).expect("Vertex not found").ty
     }
 
     fn set_edge_type(&mut self, s: V, t: V, ety: EType) {
-        *self.edata.get_mut(&s)
+        *self
+            .edata
+            .get_mut(&s)
             .expect("Source vertex not found")
             .get_mut(&t)
             .expect("Edge not found") = ety;
-        *self.edata.get_mut(&t)
+        *self
+            .edata
+            .get_mut(&t)
             .expect("Target vertex not found")
             .get_mut(&s)
             .expect("Edge not found") = ety;
     }
 
     fn edge_type_opt(&self, s: V, t: V) -> Option<EType> {
-        self.edata.get(&s)
+        self.edata
+            .get(&s)
             .expect("Source vertex not found")
             .get(&t)
             .map(|x| *x)
     }
 
-    fn set_coord(&mut self, v: V, coord: (i32,i32)) {
+    fn set_coord(&mut self, v: V, coord: (i32, i32)) {
         let d = self.vdata.get_mut(&v).expect("Vertex not found");
         d.qubit = coord.0;
         d.row = coord.1;
     }
 
-    fn coord(&mut self, v: V) -> (i32,i32) {
+    fn coord(&mut self, v: V) -> (i32, i32) {
         let d = self.vdata.get(&v).expect("Vertex not found");
         (d.qubit, d.row)
     }
 
     fn set_qubit(&mut self, v: V, qubit: i32) {
-        self.vdata.get_mut(&v)
-            .expect("Vertex not found").qubit = qubit;
+        self.vdata.get_mut(&v).expect("Vertex not found").qubit = qubit;
     }
 
     fn qubit(&self, v: V) -> i32 {
-        self.vdata.get(&v)
-            .expect("Vertex not found").qubit
+        self.vdata.get(&v).expect("Vertex not found").qubit
     }
 
     fn set_row(&mut self, v: V, row: i32) {
-        self.vdata.get_mut(&v)
-            .expect("Vertex not found").row = row;
+        self.vdata.get_mut(&v).expect("Vertex not found").row = row;
     }
 
     fn row(&self, v: V) -> i32 {
-        self.vdata.get(&v)
-            .expect("Vertex not found").row
+        self.vdata.get(&v).expect("Vertex not found").row
     }
 
     fn neighbors(&self, v: V) -> NeighborIter {
-        NeighborIter::Hash(
-            self.edata.get(&v)
-            .expect("Vertex not found")
-            .keys())
+        NeighborIter::Hash(self.edata.get(&v).expect("Vertex not found").keys())
     }
 
     fn incident_edges(&self, v: V) -> IncidentEdgeIter {
-        IncidentEdgeIter::Hash(
-            self.edata.get(&v)
-            .expect("Vertex not found")
-            .iter())
+        IncidentEdgeIter::Hash(self.edata.get(&v).expect("Vertex not found").iter())
     }
 
     fn degree(&self, v: V) -> usize {
-        self.edata.get(&v)
-            .expect("Vertex not found")
-            .len()
+        self.edata.get(&v).expect("Vertex not found").len()
     }
 
-    fn scalar(&self) -> &ScalarN { &self.scalar }
-    fn scalar_mut(&mut self) -> &mut ScalarN { &mut self.scalar }
+    fn scalar(&self) -> &ScalarN {
+        &self.scalar
+    }
+    fn scalar_mut(&mut self) -> &mut ScalarN {
+        &mut self.scalar
+    }
 
-    fn find_edge<F>(&self, f: F) -> Option<(V,V,EType)>
-        where F : Fn(V,V,EType) -> bool
+    fn find_edge<F>(&self, f: F) -> Option<(V, V, EType)>
+    where
+        F: Fn(V, V, EType) -> bool,
     {
         for (&v0, tab) in self.edata.iter() {
-            for (&v1,&et) in tab.iter() {
-                if f(v0,v1,et) { return Some((v0,v1,et)); }
+            for (&v1, &et) in tab.iter() {
+                if f(v0, v1, et) {
+                    return Some((v0, v1, et));
+                }
             }
         }
 
@@ -277,10 +292,13 @@ impl GraphLike for Graph {
     }
 
     fn find_vertex<F>(&self, f: F) -> Option<V>
-        where F : Fn(V) -> bool
+    where
+        F: Fn(V) -> bool,
     {
         for &v in self.vdata.keys() {
-            if f(v) { return Some(v); }
+            if f(v) {
+                return Some(v);
+            }
         }
 
         None
@@ -302,7 +320,7 @@ mod tests {
         assert_eq!(g.num_edges(), 0);
     }
 
-    fn simple_graph() -> (Graph,Vec<V>) {
+    fn simple_graph() -> (Graph, Vec<V>) {
         let mut g = Graph::new();
         let vs = vec![
             g.add_vertex(VType::B),
@@ -312,7 +330,8 @@ mod tests {
             g.add_vertex(VType::X),
             g.add_vertex(VType::X),
             g.add_vertex(VType::B),
-            g.add_vertex(VType::B)];
+            g.add_vertex(VType::B),
+        ];
         g.add_edge(vs[0], vs[2]);
         g.add_edge(vs[1], vs[3]);
         g.add_edge(vs[2], vs[4]);
@@ -321,23 +340,23 @@ mod tests {
         g.add_edge(vs[3], vs[5]);
         g.add_edge(vs[4], vs[6]);
         g.add_edge(vs[5], vs[7]);
-        (g,vs)
+        (g, vs)
     }
 
     #[test]
     fn create_simple_graph() {
-        let (g,_) = simple_graph();
+        let (g, _) = simple_graph();
         assert_eq!(g.num_vertices(), 8);
         assert_eq!(g.num_edges(), 8);
     }
 
     #[test]
     fn clone_graph() {
-       let (g,_) = simple_graph();
-       let h = g.clone();
-       assert!(g.num_vertices() == h.num_vertices());
-       assert!(g.num_edges() == h.num_edges());
-       // assert!(g == h);
+        let (g, _) = simple_graph();
+        let h = g.clone();
+        assert!(g.num_vertices() == h.num_vertices());
+        assert!(g.num_edges() == h.num_edges());
+        // assert!(g == h);
     }
 
     #[test]
@@ -378,7 +397,8 @@ mod tests {
             g.add_vertex(VType::B),
             g.add_vertex(VType::Z),
             g.add_vertex(VType::X),
-            g.add_vertex(VType::B)];
+            g.add_vertex(VType::B),
+        ];
         g.add_edge(vs[0], vs[1]);
         g.add_edge(vs[2], vs[3]);
 
@@ -400,4 +420,3 @@ mod tests {
         assert_eq!(h.edge_type(vs[1], vs[2]), EType::H);
     }
 }
-

--- a/quizx/src/lib.rs
+++ b/quizx/src/lib.rs
@@ -14,20 +14,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod graph;
-pub mod vec_graph;
-pub mod hash_graph;
-pub mod gate;
+pub mod annealer;
+pub mod basic_rules;
 pub mod circuit;
-pub mod optimize_circuit;
+pub mod decompose;
+pub mod extract;
+pub mod gate;
 pub mod generate;
+pub mod graph;
+pub mod hash_graph;
+pub mod linalg;
+pub mod optimize_circuit;
 pub mod random_graph;
 pub mod scalar;
-pub mod tensor;
-pub mod linalg;
-pub mod basic_rules;
 pub mod simplify;
-pub mod extract;
-pub mod decompose;
-pub mod annealer;
-
+pub mod tensor;
+pub mod vec_graph;

--- a/quizx/src/random_graph.rs
+++ b/quizx/src/random_graph.rs
@@ -1,7 +1,7 @@
 use crate::graph::*;
-use rand::{SeedableRng, Rng};
-use rand::rngs::StdRng;
 use num::Rational;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 pub struct EquatorialStabilizerStateBuilder {
     pub rng: StdRng,
@@ -16,8 +16,14 @@ impl EquatorialStabilizerStateBuilder {
         }
     }
 
-    pub fn seed(&mut self, seed: u64) -> &mut Self { self.rng = StdRng::seed_from_u64(seed); self }
-    pub fn qubits(&mut self, qubits: usize) -> &mut Self { self.qubits = qubits; self }
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.rng = StdRng::seed_from_u64(seed);
+        self
+    }
+    pub fn qubits(&mut self, qubits: usize) -> &mut Self {
+        self.qubits = qubits;
+        self
+    }
     pub fn build<G: GraphLike>(&mut self) -> G {
         let mut g = G::new();
         let outputs: Vec<_> = (0..self.qubits).map(|_| g.add_vertex(VType::B)).collect();
@@ -42,5 +48,3 @@ impl EquatorialStabilizerStateBuilder {
         g
     }
 }
-
-


### PR DESCRIPTION
Runs the standard rust code formatter.
The formatting is not currently enforced, but I'll add a CI check for it in a following PR.