### PR TITLE
fix: Lints and warnings

### DIFF
--- a/pybindings/src/lib.rs
+++ b/pybindings/src/lib.rs
@@ -40,7 +40,7 @@ fn full_simp(g: &mut VecGraph) {
 #[pyfunction]
 fn extract_circuit(g: &mut VecGraph) -> Circuit {
     Circuit {
-        c: g.g.into_circuit().unwrap(),
+        c: g.g.to_circuit().unwrap(),
         s: None,
     }
 }

--- a/pybindings/src/lib.rs
+++ b/pybindings/src/lib.rs
@@ -1,4 +1,4 @@
-use num::Rational;
+use num::Rational64;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use quizx::extract::ToCircuit;
@@ -158,7 +158,7 @@ impl VecGraph {
             3 => VType::H,
             _ => VType::B,
         };
-        let phase = Rational::new(phase.0, phase.1);
+        let phase = Rational64::new(phase.0, phase.1);
         self.g.add_vertex_with_data(VData {
             ty,
             phase,
@@ -238,11 +238,11 @@ impl VecGraph {
     }
 
     fn set_phase(&mut self, v: usize, phase: (isize, isize)) {
-        self.g.set_phase(v, Rational::new(phase.0, phase.1));
+        self.g.set_phase(v, Rational64::new(phase.0, phase.1));
     }
 
     fn add_to_phase(&mut self, v: usize, phase: (isize, isize)) {
-        self.g.add_to_phase(v, Rational::new(phase.0, phase.1));
+        self.g.add_to_phase(v, Rational64::new(phase.0, phase.1));
     }
 
     fn qubit(&mut self, v: usize) -> i32 {

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -578,7 +578,7 @@ pub fn remove_pair_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
         *g.scalar_mut() *= ScalarN::one_plus_phase(p0 + p1);
     // different colors
     } else {
-        let p2 = Rational::one() + &p0 + &p1;
+        let p2 = Rational::one() + p0 + p1;
         *g.scalar_mut() *= ScalarN::one()
             + ScalarN::from_phase(p0)
             + ScalarN::from_phase(p1)

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -29,7 +29,7 @@
 use crate::graph::*;
 use crate::scalar::*;
 use num::traits::Zero;
-use num::Rational;
+use num::Rational64;
 use rustc_hash::FxHashSet;
 use std::iter::FromIterator;
 
@@ -293,7 +293,7 @@ pub fn local_comp_unchecked(g: &mut impl GraphLike, v: V) {
 
     let x = ns.len() as i32;
     g.scalar_mut().mul_sqrt2_pow(((x - 1) * (x - 2)) / 2);
-    g.scalar_mut().mul_phase(Rational::new(*p.numer(), 4));
+    g.scalar_mut().mul_phase(Rational64::new(*p.numer(), 4));
 }
 
 checked_rule1!(check_local_comp, local_comp_unchecked, local_comp);
@@ -350,7 +350,7 @@ pub fn pivot_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
     g.scalar_mut().mul_sqrt2_pow((x - 2) * (y - 2));
 
     if !p0.is_zero() && !p1.is_zero() {
-        g.scalar_mut().mul_phase(Rational::new(1, 1));
+        g.scalar_mut().mul_phase(Rational64::new(1, 1));
     }
 }
 
@@ -366,7 +366,7 @@ fn unfuse_boundary(g: &mut impl GraphLike, v: V, b: V) {
     }
     let vd = VData {
         ty: VType::Z,
-        phase: Rational::zero(),
+        phase: Rational64::zero(),
         row: g.row(v),
         qubit: g.qubit(v),
     };
@@ -385,14 +385,14 @@ fn unfuse_gadget(g: &mut impl GraphLike, v: V) {
     }
     let vd = VData {
         ty: VType::Z,
-        phase: Rational::zero(),
+        phase: Rational64::zero(),
         row: g.row(v),
         qubit: g.qubit(v),
     };
     let v1 = g.add_vertex_with_data(vd);
     let v2 = g.add_vertex_with_data(vd);
     g.set_phase(v2, g.phase(v));
-    g.set_phase(v, Rational::zero());
+    g.set_phase(v, Rational64::zero());
     g.add_edge_with_type(v, v1, EType::H);
     g.add_edge_with_type(v1, v2, EType::H);
 }
@@ -578,7 +578,7 @@ pub fn remove_pair_unchecked(g: &mut impl GraphLike, v0: V, v1: V) {
         *g.scalar_mut() *= ScalarN::one_plus_phase(p0 + p1);
     // different colors
     } else {
-        let p2 = Rational::one() + p0 + p1;
+        let p2 = Rational64::one() + p0 + p1;
         *g.scalar_mut() *= ScalarN::one()
             + ScalarN::from_phase(p0)
             + ScalarN::from_phase(p1)
@@ -599,7 +599,7 @@ mod tests {
     use super::*;
     use crate::tensor::*;
     use crate::vec_graph::Graph;
-    use num::Rational;
+    use num::Rational64;
 
     #[test]
     fn spider_fusion_simple() {
@@ -614,8 +614,8 @@ mod tests {
             g.add_vertex(VType::B),
         ];
 
-        g.set_phase(vs[2], Rational::new(1, 2));
-        g.set_phase(vs[3], Rational::new(1, 4));
+        g.set_phase(vs[2], Rational64::new(1, 2));
+        g.set_phase(vs[3], Rational64::new(1, 4));
 
         g.add_edge(vs[0], vs[2]);
         g.add_edge(vs[1], vs[2]);
@@ -639,7 +639,7 @@ mod tests {
 
         assert_eq!(g.to_tensor4(), h.to_tensor4());
 
-        assert_eq!(g.phase(vs[2]), Rational::new(3, 4));
+        assert_eq!(g.phase(vs[2]), Rational64::new(3, 4));
     }
 
     #[test]
@@ -657,8 +657,8 @@ mod tests {
             g.add_vertex(VType::B),
         ];
 
-        g.set_phase(vs[2], Rational::new(1, 2));
-        g.set_phase(vs[3], Rational::new(1, 4));
+        g.set_phase(vs[2], Rational64::new(1, 2));
+        g.set_phase(vs[3], Rational64::new(1, 4));
 
         g.add_edge(vs[0], vs[2]);
         g.add_edge(vs[1], vs[2]);
@@ -693,14 +693,14 @@ mod tests {
         println!("\n\nth =\n{}", th);
         assert_eq!(tg, th);
 
-        assert_eq!(g.phase(vs[2]), Rational::new(3, 4));
+        assert_eq!(g.phase(vs[2]), Rational64::new(3, 4));
     }
 
     #[test]
     fn local_comp_1() {
         let mut g = Graph::new();
         g.add_vertex(VType::Z);
-        g.set_phase(0, Rational::new(1, 2));
+        g.set_phase(0, Rational64::new(1, 2));
         g.add_vertex(VType::Z);
         g.add_vertex(VType::Z);
         g.add_vertex(VType::Z);
@@ -738,12 +738,12 @@ mod tests {
         assert_eq!(tg, th);
 
         for i in 1..5 {
-            assert_eq!(g.phase(i), Rational::new(-1, 2));
+            assert_eq!(g.phase(i), Rational64::new(-1, 2));
         }
 
         assert_eq!(
             *g.scalar(),
-            Scalar::sqrt2_pow((4 - 1) * (4 - 2) / 2) * Scalar::from_phase(Rational::new(1, 4))
+            Scalar::sqrt2_pow((4 - 1) * (4 - 2) / 2) * Scalar::from_phase(Rational64::new(1, 4))
         );
 
         let h = g.clone();
@@ -759,7 +759,7 @@ mod tests {
         for _ in 0..7 {
             g.add_vertex(VType::Z);
         }
-        g.set_phase(3, Rational::new(1, 1));
+        g.set_phase(3, Rational64::new(1, 1));
         for i in 0..3 {
             g.add_edge_with_type(i, 3, EType::H);
         }
@@ -783,8 +783,8 @@ mod tests {
         assert_eq!(h.num_vertices(), 5);
         assert_eq!(h.num_edges(), 6);
 
-        assert_eq!(h.phase(0), Rational::new(0, 1));
-        assert_eq!(h.phase(6), Rational::new(1, 1));
+        assert_eq!(h.phase(0), Rational64::new(0, 1));
+        assert_eq!(h.phase(6), Rational64::new(1, 1));
 
         let mut inputs: Vec<usize> = Vec::new();
         let mut outputs: Vec<usize> = Vec::new();
@@ -816,8 +816,8 @@ mod tests {
         for _ in 0..7 {
             g.add_vertex(VType::Z);
         }
-        g.set_phase(3, Rational::new(1, 1));
-        g.set_phase(4, Rational::new(1, 1));
+        g.set_phase(3, Rational64::new(1, 1));
+        g.set_phase(4, Rational64::new(1, 1));
         for i in 0..3 {
             g.add_edge_with_type(i, 3, EType::H);
         }
@@ -835,8 +835,8 @@ mod tests {
         assert_eq!(g.num_vertices(), 5);
         assert_eq!(g.num_edges(), 6);
 
-        assert_eq!(g.phase(0), Rational::new(1, 1));
-        assert_eq!(g.phase(6), Rational::new(1, 1));
+        assert_eq!(g.phase(0), Rational64::new(1, 1));
+        assert_eq!(g.phase(6), Rational64::new(1, 1));
     }
 
     #[test]
@@ -847,8 +847,8 @@ mod tests {
             g.add_vertex(VType::Z);
         }
         g.set_vertex_type(0, VType::B);
-        // g.set_phase(3, Rational::new(1,1));
-        // g.set_phase(4, Rational::new(1,1));
+        // g.set_phase(3, Rational64::new(1,1));
+        // g.set_phase(4, Rational64::new(1,1));
         for i in 0..3 {
             g.add_edge_with_type(i, 3, EType::H);
         }
@@ -881,8 +881,8 @@ mod tests {
         for _ in 0..7 {
             g.add_vertex(VType::Z);
         }
-        g.set_phase(3, Rational::new(1, 1));
-        g.set_phase(4, Rational::new(1, 4));
+        g.set_phase(3, Rational64::new(1, 1));
+        g.set_phase(4, Rational64::new(1, 4));
         for i in 0..3 {
             g.add_edge_with_type(i, 3, EType::H);
         }
@@ -928,20 +928,20 @@ mod tests {
                 }
             }
 
-            g.set_phase(ps[0], Rational::new(1, 4));
-            g.set_phase(ps[1], Rational::new(1, 2));
+            g.set_phase(ps[0], Rational64::new(1, 4));
+            g.set_phase(ps[1], Rational64::new(1, 2));
 
             let h = g.clone();
 
             assert!(gadget_fusion(&mut g, gs[0], gs[1]));
             assert!(g
-                .find_vertex(|v| g.phase(v) == Rational::new(3, 4))
+                .find_vertex(|v| g.phase(v) == Rational64::new(3, 4))
                 .is_some());
             assert!(g
-                .find_vertex(|v| g.phase(v) == Rational::new(1, 4))
+                .find_vertex(|v| g.phase(v) == Rational64::new(1, 4))
                 .is_none());
             assert!(g
-                .find_vertex(|v| g.phase(v) == Rational::new(1, 2))
+                .find_vertex(|v| g.phase(v) == Rational64::new(1, 2))
                 .is_none());
             // println!("{}", g.to_tensor4());
             // println!("{}", h.to_tensor4());
@@ -955,7 +955,7 @@ mod tests {
     fn scalar_rules() {
         for &t in &[VType::Z, VType::X] {
             let mut g = Graph::new();
-            g.add_vertex_with_phase(t, Rational::new(1, 4));
+            g.add_vertex_with_phase(t, Rational64::new(1, 4));
             let mut h = g.clone();
             assert!(remove_single(&mut h, 0));
             assert_eq!(h.num_vertices(), 0, "h still has vertices");
@@ -966,8 +966,8 @@ mod tests {
             for &t1 in &[VType::Z, VType::X] {
                 for &et in &[EType::N, EType::H] {
                     let mut g = Graph::new();
-                    g.add_vertex_with_phase(t0, Rational::new(1, 4));
-                    g.add_vertex_with_phase(t1, Rational::new(-1, 2));
+                    g.add_vertex_with_phase(t0, Rational64::new(1, 4));
+                    g.add_vertex_with_phase(t1, Rational64::new(-1, 2));
                     g.add_edge_with_type(0, 1, et);
                     let mut h = g.clone();
                     assert!(remove_pair(&mut h, 0, 1));

--- a/quizx/src/basic_rules.rs
+++ b/quizx/src/basic_rules.rs
@@ -911,43 +911,43 @@ mod tests {
     fn gadget_fusion_1() {
         // fuse gadgets of various sizes
         for n in 1..5 {
-            let mut g = Graph::new();
-            let bs: Vec<_> = (0..n).map(|_| g.add_vertex(VType::B)).collect();
-            let vs: Vec<_> = (0..n).map(|_| g.add_vertex(VType::Z)).collect();
-            let gs: Vec<_> = (0..2).map(|_| g.add_vertex(VType::Z)).collect();
-            let ps: Vec<_> = (0..2).map(|_| g.add_vertex(VType::Z)).collect();
-            g.set_inputs(bs.clone());
+            let mut graph = Graph::new();
+            let bs: Vec<_> = (0..n).map(|_| graph.add_vertex(VType::B)).collect();
+            let vs: Vec<_> = (0..n).map(|_| graph.add_vertex(VType::Z)).collect();
+            let gs: Vec<_> = (0..2).map(|_| graph.add_vertex(VType::Z)).collect();
+            let ps: Vec<_> = (0..2).map(|_| graph.add_vertex(VType::Z)).collect();
+            graph.set_inputs(bs.clone());
 
             for i in 0..n {
-                g.add_edge(bs[i], vs[i]);
+                graph.add_edge(bs[i], vs[i]);
             }
-            for j in 0..2 {
-                g.add_edge_with_type(gs[j], ps[j], EType::H);
-                for i in 0..n {
-                    g.add_edge_with_type(vs[i], gs[j], EType::H);
+            for (&g, &p) in gs.iter().zip(ps.iter()) {
+                graph.add_edge_with_type(g, p, EType::H);
+                for &v in &vs {
+                    graph.add_edge_with_type(v, g, EType::H);
                 }
             }
 
-            g.set_phase(ps[0], Rational64::new(1, 4));
-            g.set_phase(ps[1], Rational64::new(1, 2));
+            graph.set_phase(ps[0], Rational64::new(1, 4));
+            graph.set_phase(ps[1], Rational64::new(1, 2));
 
-            let h = g.clone();
+            let h = graph.clone();
 
-            assert!(gadget_fusion(&mut g, gs[0], gs[1]));
-            assert!(g
-                .find_vertex(|v| g.phase(v) == Rational64::new(3, 4))
+            assert!(gadget_fusion(&mut graph, gs[0], gs[1]));
+            assert!(graph
+                .find_vertex(|v| graph.phase(v) == Rational64::new(3, 4))
                 .is_some());
-            assert!(g
-                .find_vertex(|v| g.phase(v) == Rational64::new(1, 4))
+            assert!(graph
+                .find_vertex(|v| graph.phase(v) == Rational64::new(1, 4))
                 .is_none());
-            assert!(g
-                .find_vertex(|v| g.phase(v) == Rational64::new(1, 2))
+            assert!(graph
+                .find_vertex(|v| graph.phase(v) == Rational64::new(1, 2))
                 .is_none());
             // println!("{}", g.to_tensor4());
             // println!("{}", h.to_tensor4());
             // println!("g = {} * \n {} \n\n", g.scalar(), g.to_dot());
             // println!("h = {} * \n {} \n\n", h.scalar(), h.to_dot());
-            assert_eq!(g.to_tensor4(), h.to_tensor4());
+            assert_eq!(graph.to_tensor4(), h.to_tensor4());
         }
     }
 

--- a/quizx/src/bin/cnot_anneal.rs
+++ b/quizx/src/bin/cnot_anneal.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let time = Instant::now();
     println!("{}", f);
     let c = Circuit::from_file(f)
-        .expect(&format!("circuit failed to parse: {}", f))
+        .unwrap_or_else(|_| panic!("circuit failed to parse: {}", f))
         .to_basic_gates();
     println!("...done reading in {:.2?}", time.elapsed());
 

--- a/quizx/src/bin/hidden_shift_stabrank.rs
+++ b/quizx/src/bin/hidden_shift_stabrank.rs
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     if shift == shift_m {
         print!("OK {}", data);
-        fs::write(&format!("hidden_shift_{}_{}_{}", qs, n_ccz, seed), data)
+        fs::write(format!("hidden_shift_{}_{}_{}", qs, n_ccz, seed), data)
             .expect("Unable to write file");
     } else {
         print!("FAILED {}", data);

--- a/quizx/src/bin/pauli_gadget_stabrank.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank.rs
@@ -183,7 +183,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
-                let check_prob = &amp * &amp.conj();
+                let check_prob = amp * amp.conj();
                 if Scalar::from_scalar(&check_prob) == prob {
                     println!("OK");
                     true
@@ -216,7 +216,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if success {
         print!("OK {}", data);
         fs::write(
-            &format!(
+            format!(
                 "pauli_gadget_{}_{}_{}_{}_{}_{}",
                 qs, depth, min_weight, max_weight, nsamples, seed
             ),

--- a/quizx/src/bin/pauli_gadget_stabrank_met.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank_met.rs
@@ -184,7 +184,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
-                let check_prob = &amp * &amp.conj();
+                let check_prob = amp * amp.conj();
                 if Scalar::from_scalar(&check_prob) == prob {
                     println!("OK");
                     true
@@ -217,7 +217,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if success {
         print!("OK {}", data);
         fs::write(
-            &format!(
+            format!(
                 "pauli_gadget_{}_{}_{}_{}_{}_{}",
                 qs, depth, min_weight, max_weight, nsamples, seed
             ),

--- a/quizx/src/bin/pauli_gadget_stabrank_ne.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank_ne.rs
@@ -204,7 +204,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
-                let check_prob = &amp * &amp.conj();
+                let check_prob = amp * amp.conj();
                 if Scalar::from_scalar(&check_prob) == prob {
                     println!("OK");
                     true
@@ -237,7 +237,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if success {
         print!("OK {}", data);
         fs::write(
-            &format!(
+            format!(
                 "pauli_gadget_{}_{}_{}_{}_{}_{}",
                 qs, depth, min_weight, max_weight, nsamples, seed
             ),

--- a/quizx/src/bin/pauli_gadget_stabrank_single.rs
+++ b/quizx/src/bin/pauli_gadget_stabrank_single.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 check.plug_inputs(&vec![BasisElem::Z0; qs]);
                 check.plug_outputs(&effect);
                 let amp = check.to_tensor4()[[]];
-                let check_prob = &amp * &amp.conj();
+                let check_prob = amp * amp.conj();
                 if Scalar::from_scalar(&check_prob) == prob {
                     println!("OK");
                     true
@@ -176,7 +176,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     if success {
         print!("OK {}", data);
         fs::write(
-            &format!(
+            format!(
                 "pauli_gadget_{}_{}_{}_{}_{}_{}",
                 qs, depth, min_weight, max_weight, nsamples, seed
             ),

--- a/quizx/src/bin/read_circuits.rs
+++ b/quizx/src/bin/read_circuits.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(f) = e?.path().to_str() {
             let time = Instant::now();
             println!("{}", f);
-            Circuit::from_file(f).expect(&format!("circuit failed to parse: {}", f));
+            Circuit::from_file(f).unwrap_or_else(|_| panic!("circuit failed to parse: {}", f));
             println!("...done in {:.2?}", time.elapsed());
         }
     }

--- a/quizx/src/bin/spider_chain.rs
+++ b/quizx/src/bin/spider_chain.rs
@@ -39,11 +39,8 @@ fn main() {
     println!("Fusing all spiders...");
     let time = Instant::now();
 
-    loop {
-        match g.find_edge(|v0, v1, _| check_spider_fusion(&g, v0, v1)) {
-            Some((v0, v1, _)) => spider_fusion_unchecked(&mut g, v0, v1),
-            None => break,
-        };
+    while let Some((v0, v1, _)) = g.find_edge(|v0, v1, _| check_spider_fusion(&g, v0, v1)) {
+        spider_fusion_unchecked(&mut g, v0, v1)
     }
 
     println!("Done in {:.2?}", time.elapsed());

--- a/quizx/src/bin/test_all.rs
+++ b/quizx/src/bin/test_all.rs
@@ -27,7 +27,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(f) = e?.path().to_str() {
             let time = Instant::now();
             println!("{}", f);
-            let c = Circuit::from_file(f).unwrap_or_else(|_| panic!("circuit failed to parse: {}", f));
+            let c =
+                Circuit::from_file(f).unwrap_or_else(|_| panic!("circuit failed to parse: {}", f));
             println!("...done reading in {:.2?}", time.elapsed());
             // if c.num_qubits() > 10 { continue; }
 

--- a/quizx/src/bin/test_all.rs
+++ b/quizx/src/bin/test_all.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Some(f) = e?.path().to_str() {
             let time = Instant::now();
             println!("{}", f);
-            let c = Circuit::from_file(f).expect(&format!("circuit failed to parse: {}", f));
+            let c = Circuit::from_file(f).unwrap_or_else(|_| panic!("circuit failed to parse: {}", f));
             println!("...done reading in {:.2?}", time.elapsed());
             // if c.num_qubits() > 10 { continue; }
 

--- a/quizx/src/bin/test_one.rs
+++ b/quizx/src/bin/test_one.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let f = "../circuits/large/gf2^64_mult.qasm";
     let time = Instant::now();
     println!("{}", f);
-    let c = Circuit::from_file(f).expect(&format!("circuit failed to parse: {}", f));
+    let c = Circuit::from_file(f).unwrap_or_else(|_| panic!("circuit failed to parse: {}", f));
     println!("...done reading in {:.2?}", time.elapsed());
 
     // println!("Computing tensor");

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -390,6 +390,7 @@ struct CircuitWriter {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 enum CircuitWriterError {
     UnitaryNotSupported,
     BarrierNotSupported,

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -308,10 +308,10 @@ impl Circuit {
 
 impl fmt::Display for Circuit {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "qreg q[{}];\n", self.num_qubits())?;
+        writeln!(f, "qreg q[{}];", self.num_qubits())?;
 
         for g in &self.gates {
-            write!(f, "{};\n", g.to_qasm())?;
+            writeln!(f, "{};", g.to_qasm())?;
         }
 
         Ok(())
@@ -449,7 +449,7 @@ impl openqasm::GateWriter for &mut CircuitWriter {
 
         let mut g = Gate::from_qasm_name(name.as_str());
         g.qs.extend_from_slice(regs);
-        if params.len() > 0 {
+        if !params.is_empty() {
             g.phase = param_to_ratio(params[0]);
         }
 

--- a/quizx/src/circuit.rs
+++ b/quizx/src/circuit.rs
@@ -18,7 +18,7 @@ use crate::gate::*;
 use crate::graph::*;
 use crate::linalg::RowOps;
 use crate::scalar::Mod2;
-use num::{Rational, Zero};
+use num::{Rational64, Zero};
 use openqasm::{ast::Symbol, translate::Value, GenericError, ProgramVisitor};
 use std::collections::VecDeque;
 use std::fmt;
@@ -142,7 +142,7 @@ impl Circuit {
         self.gates.push_front(g);
     }
 
-    pub fn add_gate_with_phase(&mut self, name: &str, qs: Vec<usize>, phase: Rational) {
+    pub fn add_gate_with_phase(&mut self, name: &str, qs: Vec<usize>, phase: Rational64) {
         self.push(Gate {
             t: GType::from_qasm_name(name),
             qs,
@@ -151,7 +151,7 @@ impl Circuit {
     }
 
     pub fn add_gate(&mut self, name: &str, qs: Vec<usize>) {
-        self.add_gate_with_phase(name, qs, Rational::zero());
+        self.add_gate_with_phase(name, qs, Rational64::zero());
     }
 
     pub fn reverse(&mut self) {
@@ -256,7 +256,7 @@ impl Circuit {
         for i in 0..self.nqubits {
             let v = graph.add_vertex_with_data(VData {
                 ty: VType::B,
-                phase: Rational::zero(),
+                phase: Rational64::zero(),
                 qubit: i as i32,
                 row: 1,
             });
@@ -284,7 +284,7 @@ impl Circuit {
             if let Some(v0) = q {
                 let v = graph.add_vertex_with_data(VData {
                     ty: VType::B,
-                    phase: Rational::zero(),
+                    phase: Rational64::zero(),
                     qubit: i as i32,
                     row: last_row + 1,
                 });
@@ -436,14 +436,14 @@ impl openqasm::GateWriter for &mut CircuitWriter {
         params: &[Value],
         regs: &[usize],
     ) -> Result<(), Self::Error> {
-        fn param_to_ratio(value: Value) -> num::Rational {
+        fn param_to_ratio(value: Value) -> num::Rational64 {
             if value.a.is_zero() {
-                num::Rational::new(*value.b.numer() as isize, *value.b.denom() as isize).mod2()
+                num::Rational64::new(*value.b.numer(), *value.b.denom()).mod2()
             } else {
                 let a = *value.a.numer() as f32 / *value.a.denom() as f32;
-                let mut p =
-                    num::Rational::approximate_float(a / std::f32::consts::PI).unwrap_or(0.into());
-                p += num::Rational::new(*value.b.numer() as isize, *value.b.denom() as isize);
+                let mut p = num::Rational64::approximate_float(a / std::f32::consts::PI)
+                    .unwrap_or(0.into());
+                p += num::Rational64::new(*value.b.numer(), *value.b.denom());
                 p.mod2()
             }
         }
@@ -517,17 +517,17 @@ mod tests {
     #[test]
     fn mk_circuit_with_phase() {
         let mut c = Circuit::new(1);
-        c.add_gate_with_phase("rz", vec![0], Rational::new(1, 1));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(1, 1));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(1, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(1, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(2, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(2, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(-1, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(-1, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(-1, 3));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(1, 1));
-        c.add_gate_with_phase("rz", vec![0], Rational::new(-1, 2));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(1, 1));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(1, 1));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(1, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(1, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(2, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(2, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(-1, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(-1, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(-1, 3));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(1, 1));
+        c.add_gate_with_phase("rz", vec![0], Rational64::new(-1, 2));
 
         let qasm = r#"
             OPENQASM 2.0;
@@ -602,8 +602,8 @@ mod tests {
 
         println!("g = {}\n\nh = {}\n\n", g.to_dot(), h.to_dot());
 
-        assert_eq!(c.to_tensor4(), Tensor::cphase(Rational::new(1, 1), 2));
-        assert_eq!(g.to_tensor4(), Tensor::cphase(Rational::new(1, 1), 2));
+        assert_eq!(c.to_tensor4(), Tensor::cphase(Rational64::new(1, 1), 2));
+        assert_eq!(g.to_tensor4(), Tensor::cphase(Rational64::new(1, 1), 2));
     }
 
     #[test]

--- a/quizx/src/decompose.rs
+++ b/quizx/src/decompose.rs
@@ -16,7 +16,7 @@
 
 use crate::graph::*;
 use crate::scalar::*;
-use num::Rational;
+use num::Rational64;
 use rand::{thread_rng, Rng};
 use rayon::prelude::*;
 use std::collections::VecDeque;
@@ -422,15 +422,15 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone(); // that is annoying ...
         let mut verts = Vec::from(verts);
         if g.phase(verts[0]).numer() == &1 {
-            g.set_phase(verts[0], Rational::new(0, 1));
+            g.set_phase(verts[0], Rational64::new(0, 1));
             let mut neigh = g.neighbor_vec(verts[1]);
             neigh.retain(|&x| x != verts[0]);
             for &v in &neigh {
-                g.add_to_phase(v, Rational::new(1, 1));
+                g.add_to_phase(v, Rational64::new(1, 1));
             }
             let tmp = g.phase(verts[1]);
             *g.scalar_mut() *= ScalarN::from_phase(tmp);
-            g.set_phase(verts[1], g.phase(verts[1]) * Rational::new(-1, 1));
+            g.set_phase(verts[1], g.phase(verts[1]) * Rational64::new(-1, 1));
         }
         if [3, 5].contains(&verts[1..].len()) {
             let w = g.add_vertex(VType::Z);
@@ -467,10 +467,10 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, 0, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
             g.set_edge_type(v, verts[0], EType::N);
         }
-        g.set_phase(verts[0], Rational::new(-1, 2));
+        g.set_phase(verts[0], Rational64::new(-1, 2));
         g
     }
 
@@ -478,7 +478,7 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-1, vec![-1, 0, 1, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
         }
         g
     }
@@ -487,7 +487,7 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(7, vec![0, -1, 0, 0]);
         for i in 1..verts.len() {
-            g.add_to_phase(verts[i], Rational::new(-1, 4));
+            g.add_to_phase(verts[i], Rational64::new(-1, 4));
             for j in i + 1..verts.len() {
                 g.add_edge_smart(verts[i], verts[j], EType::H);
             }
@@ -499,10 +499,10 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(1, vec![1, 0, 0, 0]);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
             g.add_edge_smart(v, verts[0], EType::N);
         }
-        g.add_to_phase(verts[0], Rational::new(-3, 4));
+        g.add_to_phase(verts[0], Rational64::new(-3, 4));
         g
     }
 
@@ -511,10 +511,10 @@ impl<G: GraphLike> Decomposer<G> {
         *g.scalar_mut() *= ScalarN::Exact(1, vec![-1, 0, 1, 0]);
         let p = g.add_vertex(VType::Z);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
             g.add_edge_with_type(v, p, EType::H);
         }
-        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1, 4));
+        let w = g.add_vertex_with_phase(VType::Z, Rational64::new(-1, 4));
         g.add_edge_with_type(w, p, EType::H);
         g
     }
@@ -523,10 +523,10 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(9, vec![0, -1, 0, 0]);
         let p = g.add_vertex(VType::Z);
-        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1, 4));
+        let w = g.add_vertex_with_phase(VType::Z, Rational64::new(-1, 4));
         g.add_edge_with_type(p, w, EType::H);
         for i in 0..verts.len() {
-            g.add_to_phase(verts[i], Rational::new(-1, 4));
+            g.add_to_phase(verts[i], Rational64::new(-1, 4));
             g.add_edge_with_type(verts[i], p, EType::H);
             g.add_edge_with_type(verts[i], w, EType::H);
             for j in i + 1..verts.len() {
@@ -540,7 +540,7 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(0, vec![0, 0, 1, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
         }
         g
     }
@@ -550,10 +550,10 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, -1, 0]);
         for &v in &verts[1..] {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
             g.set_edge_type(v, verts[0], EType::N);
         }
-        g.set_phase(verts[0], Rational::new(-1, 2));
+        g.set_phase(verts[0], Rational64::new(-1, 2));
         g
     }
 
@@ -562,7 +562,7 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-2, vec![-1, 0, 1, 1]);
         for &v in &verts[0..6] {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
         }
         g
     }
@@ -572,7 +572,7 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-2, vec![-1, 0, 1, -1]);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(3, 4));
+            g.add_to_phase(v, Rational64::new(3, 4));
         }
         g
     }
@@ -582,9 +582,9 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(1, vec![0, -1, 0, 0]);
 
-        let w = g.add_vertex_with_phase(VType::Z, Rational::one());
+        let w = g.add_vertex_with_phase(VType::Z, Rational64::one());
         for &v in verts {
-            g.add_to_phase(v, Rational::new(1, 4));
+            g.add_to_phase(v, Rational64::new(1, 4));
             g.add_edge_with_type(v, w, EType::H);
         }
 
@@ -598,7 +598,7 @@ impl<G: GraphLike> Decomposer<G> {
 
         let w = g.add_vertex(VType::Z);
         for &v in verts {
-            g.add_to_phase(v, Rational::new(1, 4));
+            g.add_to_phase(v, Rational64::new(1, 4));
             g.add_edge_with_type(v, w, EType::H);
         }
 
@@ -610,9 +610,9 @@ impl<G: GraphLike> Decomposer<G> {
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(1, vec![1, 0, 0, 0]);
 
-        let w = g.add_vertex_with_phase(VType::Z, Rational::new(-1, 2));
+        let w = g.add_vertex_with_phase(VType::Z, Rational64::new(-1, 2));
         for &v in verts {
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
             g.add_edge_with_type(v, w, EType::N);
         }
 
@@ -630,10 +630,10 @@ impl<G: GraphLike> Decomposer<G> {
             ws.push(w);
             g.add_edge_with_type(verts[i], ws[i], EType::H);
             g.add_edge_with_type(ws[i], verts[5], EType::H);
-            g.add_to_phase(verts[i], Rational::new(-1, 4));
+            g.add_to_phase(verts[i], Rational64::new(-1, 4));
         }
 
-        g.add_to_phase(verts[5], Rational::new(3, 4));
+        g.add_to_phase(verts[5], Rational64::new(3, 4));
 
         g.add_edge_with_type(ws[0], ws[2], EType::H);
         g.add_edge_with_type(ws[0], ws[3], EType::H);
@@ -656,8 +656,8 @@ impl<G: GraphLike> Decomposer<G> {
         // println!("replace_bell_s");
         let mut g = g.clone();
         g.add_edge_smart(verts[0], verts[1], EType::N);
-        g.add_to_phase(verts[0], Rational::new(-1, 4));
-        g.add_to_phase(verts[1], Rational::new(1, 4));
+        g.add_to_phase(verts[0], Rational64::new(-1, 4));
+        g.add_to_phase(verts[1], Rational64::new(1, 4));
 
         g
     }
@@ -665,11 +665,11 @@ impl<G: GraphLike> Decomposer<G> {
     fn replace_epr(g: &G, verts: &[V]) -> G {
         // println!("replace_epr");
         let mut g = g.clone();
-        *g.scalar_mut() *= ScalarN::from_phase(Rational::new(1, 4));
-        let w = g.add_vertex_with_phase(VType::Z, Rational::one());
+        *g.scalar_mut() *= ScalarN::from_phase(Rational64::new(1, 4));
+        let w = g.add_vertex_with_phase(VType::Z, Rational64::one());
         for &v in verts {
             g.add_edge_with_type(v, w, EType::H);
-            g.add_to_phase(v, Rational::new(-1, 4));
+            g.add_to_phase(v, Rational64::new(-1, 4));
         }
 
         g
@@ -681,7 +681,7 @@ impl<G: GraphLike> Decomposer<G> {
         *g.scalar_mut() *= ScalarN::Exact(-1, vec![0, 1, 0, -1]);
         let w = g.add_vertex(VType::Z);
         g.add_edge_with_type(verts[0], w, EType::H);
-        g.add_to_phase(verts[0], Rational::new(-1, 4));
+        g.add_to_phase(verts[0], Rational64::new(-1, 4));
         g
     }
 
@@ -689,9 +689,9 @@ impl<G: GraphLike> Decomposer<G> {
         // println!("replace_t1");
         let mut g = g.clone();
         *g.scalar_mut() *= ScalarN::Exact(-1, vec![1, 0, 1, 0]);
-        let w = g.add_vertex_with_phase(VType::Z, Rational::one());
+        let w = g.add_vertex_with_phase(VType::Z, Rational64::one());
         g.add_edge_with_type(verts[0], w, EType::H);
-        g.add_to_phase(verts[0], Rational::new(-1, 4));
+        g.add_to_phase(verts[0], Rational64::new(-1, 4));
         g
     }
 }
@@ -736,7 +736,7 @@ mod tests {
     #[test]
     fn single_scalars() {
         let s0 = ScalarN::sqrt2_pow(-1);
-        let s1 = ScalarN::from_phase(Rational::new(1, 4)) * &s0;
+        let s1 = ScalarN::from_phase(Rational64::new(1, 4)) * &s0;
         println!("s0 = {:?}\ns1 = {:?}", s0, s1);
         assert_eq!(s0, ScalarN::Exact(-1, vec![0, 1, 0, -1]));
         assert_eq!(s1, ScalarN::Exact(-1, vec![1, 0, 1, 0]));
@@ -745,7 +745,7 @@ mod tests {
     #[test]
     fn single() {
         let mut g = Graph::new();
-        let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+        let v = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
         let w = g.add_vertex(VType::B);
         g.add_edge(v, w);
         g.set_outputs(vec![w]);
@@ -767,7 +767,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..2 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -791,7 +791,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..6 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -815,7 +815,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..9 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -842,7 +842,7 @@ mod tests {
     fn mixed_sc() {
         let mut g = Graph::new();
         for i in 0..11 {
-            g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+            g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
 
             for j in 0..i {
                 g.add_edge_with_type(i, j, EType::H);
@@ -866,7 +866,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..9 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);
@@ -888,7 +888,7 @@ mod tests {
         let mut g = Graph::new();
         let mut outs = vec![];
         for _ in 0..9 {
-            let v = g.add_vertex_with_phase(VType::Z, Rational::new(1, 4));
+            let v = g.add_vertex_with_phase(VType::Z, Rational64::new(1, 4));
             let w = g.add_vertex(VType::B);
             outs.push(w);
             g.add_edge(v, w);

--- a/quizx/src/extract.rs
+++ b/quizx/src/extract.rs
@@ -20,7 +20,7 @@ use crate::graph::*;
 // use crate::tensor::*;
 use crate::basic_rules::{boundary_pivot, remove_id};
 use crate::linalg::*;
-use num::{Rational, Zero};
+use num::{Rational64, Zero};
 use rustc_hash::FxHashSet;
 use std::fmt;
 
@@ -291,7 +291,7 @@ impl<'a, G: GraphLike> Extractor<'a, G> {
                 let p = self.g.phase(v);
                 if !p.is_zero() {
                     c.push_front(Gate::new_with_phase(ZPhase, vec![q], p));
-                    self.g.set_phase(v, Rational::zero());
+                    self.g.set_phase(v, Rational64::zero());
                 }
 
                 // inspect neighbors of the frontier vertex
@@ -315,7 +315,7 @@ impl<'a, G: GraphLike> Extractor<'a, G> {
                         if self.g.degree(v) > 2 {
                             let vd = VData {
                                 ty: VType::Z,
-                                phase: Rational::zero(),
+                                phase: Rational64::zero(),
                                 qubit: self.g.qubit(n),
                                 row: self.g.row(n) + 1,
                             };

--- a/quizx/src/extract.rs
+++ b/quizx/src/extract.rs
@@ -44,9 +44,9 @@ impl<G: GraphLike> fmt::Debug for ExtractError<G> {
 impl<G: GraphLike> std::error::Error for ExtractError<G> {}
 
 pub trait ToCircuit: GraphLike {
-    fn into_circuit(&mut self) -> Result<Circuit, ExtractError<Self>>;
+    fn to_circuit_mut(&mut self) -> Result<Circuit, ExtractError<Self>>;
     fn to_circuit(&self) -> Result<Circuit, ExtractError<Self>> {
-        self.clone().into_circuit()
+        self.clone().to_circuit_mut()
     }
 
     fn extractor(&mut self) -> Extractor<Self> {
@@ -480,7 +480,7 @@ impl<'a, G: GraphLike> Extractor<'a, G> {
 }
 
 impl<G: GraphLike + Clone> ToCircuit for G {
-    fn into_circuit(&mut self) -> Result<Circuit, ExtractError<G>> {
+    fn to_circuit_mut(&mut self) -> Result<Circuit, ExtractError<G>> {
         Extractor::new(self).extract()
     }
 }

--- a/quizx/src/extract.rs
+++ b/quizx/src/extract.rs
@@ -118,17 +118,15 @@ impl<'a, G: GraphLike> Extractor<'a, G> {
     }
 
     /// Set edges between frontier and given neighbors to match biadj. matrix
-    fn update_frontier_biadj(&mut self, neighbors: &Vec<V>, m: Mat2) {
+    fn update_frontier_biadj(&mut self, neighbors: &[V], m: Mat2) {
         for (i, &(_, v)) in self.frontier.iter().enumerate() {
             for (j, &w) in neighbors.iter().enumerate() {
                 if m[(i, j)] == 1 {
                     if !self.g.connected(v, w) {
                         self.g.add_edge_with_type(v, w, EType::H);
                     }
-                } else {
-                    if self.g.connected(v, w) {
-                        self.g.remove_edge(v, w);
-                    }
+                } else if self.g.connected(v, w) {
+                    self.g.remove_edge(v, w);
                 }
             }
         }

--- a/quizx/src/gate.rs
+++ b/quizx/src/gate.rs
@@ -173,7 +173,7 @@ impl Gate {
         Gate { t, qs, phase }
     }
 
-    fn push_ccz_decomp(circ: &mut Circuit, qs: &Vec<usize>) {
+    fn push_ccz_decomp(circ: &mut Circuit, qs: &[usize]) {
         circ.push(Gate::new(CNOT, vec![qs[1], qs[2]]));
         circ.push(Gate::new(Tdg, vec![qs[2]]));
         circ.push(Gate::new(CNOT, vec![qs[0], qs[2]]));
@@ -236,7 +236,7 @@ impl Gate {
 
     fn add_spider<G: GraphLike>(
         graph: &mut G,
-        qs: &mut Vec<Option<usize>>,
+        qs: &mut [Option<usize>],
         qubit: usize,
         ty: VType,
         et: EType,
@@ -264,7 +264,7 @@ impl Gate {
     /// only for applications where the circuit doesn't need to be re-extracted (e.g. classical simulation).
     fn add_ccz_postselected<G: GraphLike>(
         graph: &mut G,
-        qs: &mut Vec<Option<usize>>,
+        qs: &mut [Option<usize>],
         qubits: &[usize],
     ) {
         if qs[qubits[0]].is_some() && qs[qubits[1]].is_some() && qs[qubits[2]].is_some() {

--- a/quizx/src/gate.rs
+++ b/quizx/src/gate.rs
@@ -17,7 +17,7 @@
 use crate::circuit::Circuit;
 use crate::graph::*;
 use crate::scalar::*;
-use num::{Rational, Zero};
+use num::{Rational64, Zero};
 use std::cmp::max;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -115,7 +115,7 @@ impl GType {
 pub struct Gate {
     pub t: GType,
     pub qs: Vec<usize>,
-    pub phase: Rational,
+    pub phase: Rational64,
 }
 
 impl Gate {
@@ -123,7 +123,7 @@ impl Gate {
         Gate {
             t: GType::from_qasm_name(s),
             qs: vec![],
-            phase: Rational::zero(),
+            phase: Rational64::zero(),
         }
     }
 
@@ -165,11 +165,11 @@ impl Gate {
         Gate {
             t,
             qs,
-            phase: Rational::zero(),
+            phase: Rational64::zero(),
         }
     }
 
-    pub fn new_with_phase(t: GType, qs: Vec<usize>, phase: Rational) -> Gate {
+    pub fn new_with_phase(t: GType, qs: Vec<usize>, phase: Rational64) -> Gate {
         Gate { t, qs, phase }
     }
 
@@ -240,7 +240,7 @@ impl Gate {
         qubit: usize,
         ty: VType,
         et: EType,
-        phase: Rational,
+        phase: Rational64,
     ) -> Option<usize> {
         if let Some(v0) = qs[qubit] {
             let row = graph.row(v0) + 1;
@@ -268,9 +268,9 @@ impl Gate {
         qubits: &[usize],
     ) {
         if qs[qubits[0]].is_some() && qs[qubits[1]].is_some() && qs[qubits[2]].is_some() {
-            let v0 = Gate::add_spider(graph, qs, qubits[0], VType::Z, EType::N, Rational::zero())
+            let v0 = Gate::add_spider(graph, qs, qubits[0], VType::Z, EType::N, Rational64::zero())
                 .unwrap();
-            let v1 = Gate::add_spider(graph, qs, qubits[1], VType::Z, EType::N, Rational::zero())
+            let v1 = Gate::add_spider(graph, qs, qubits[1], VType::Z, EType::N, Rational64::zero())
                 .unwrap();
             let v2 = Gate::add_spider(
                 graph,
@@ -278,12 +278,12 @@ impl Gate {
                 qubits[2],
                 VType::Z,
                 EType::N,
-                Rational::new(-1, 2),
+                Rational64::new(-1, 2),
             )
             .unwrap();
             // add spiders, 3 in "circuit-like" positions, and one extra
             let s = graph.add_vertex(VType::Z);
-            graph.set_phase(s, Rational::new(-1, 4));
+            graph.set_phase(s, Rational64::new(-1, 4));
             graph.add_edge_with_type(s, v2, EType::H);
 
             // add 3 phase gadgets
@@ -297,9 +297,9 @@ impl Gate {
                 graph.add_vertex(VType::Z),
                 graph.add_vertex(VType::Z),
             ];
-            graph.set_phase(g1[0], Rational::new(-1, 4));
-            graph.set_phase(g1[1], Rational::new(-1, 4));
-            graph.set_phase(g1[2], Rational::new(1, 4));
+            graph.set_phase(g1[0], Rational64::new(-1, 4));
+            graph.set_phase(g1[1], Rational64::new(-1, 4));
+            graph.set_phase(g1[2], Rational64::new(1, 4));
             for i in 0..3 {
                 graph.add_edge_with_type(g1[i], g0[i], EType::H);
             }
@@ -339,7 +339,7 @@ impl Gate {
                     self.qs[0],
                     VType::Z,
                     EType::N,
-                    Rational::new(1, 1),
+                    Rational64::new(1, 1),
                 );
             }
             S => {
@@ -349,7 +349,7 @@ impl Gate {
                     self.qs[0],
                     VType::Z,
                     EType::N,
-                    Rational::new(1, 2),
+                    Rational64::new(1, 2),
                 );
             }
             Sdg => {
@@ -359,7 +359,7 @@ impl Gate {
                     self.qs[0],
                     VType::Z,
                     EType::N,
-                    Rational::new(-1, 2),
+                    Rational64::new(-1, 2),
                 );
             }
             T => {
@@ -369,7 +369,7 @@ impl Gate {
                     self.qs[0],
                     VType::Z,
                     EType::N,
-                    Rational::new(1, 4),
+                    Rational64::new(1, 4),
                 );
             }
             Tdg => {
@@ -379,7 +379,7 @@ impl Gate {
                     self.qs[0],
                     VType::Z,
                     EType::N,
-                    Rational::new(-1, 4),
+                    Rational64::new(-1, 4),
                 );
             }
             XPhase => {
@@ -392,16 +392,37 @@ impl Gate {
                     self.qs[0],
                     VType::X,
                     EType::N,
-                    Rational::new(1, 1),
+                    Rational64::new(1, 1),
                 );
             }
             HAD => {
-                Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::H, Rational::zero());
+                Gate::add_spider(
+                    graph,
+                    qs,
+                    self.qs[0],
+                    VType::Z,
+                    EType::H,
+                    Rational64::zero(),
+                );
             }
             CNOT => {
                 if let (Some(v1), Some(v2)) = (
-                    Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Rational::zero()),
-                    Gate::add_spider(graph, qs, self.qs[1], VType::X, EType::N, Rational::zero()),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[0],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[1],
+                        VType::X,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
                 ) {
                     let row = max(graph.row(v1), graph.row(v2));
                     graph.set_row(v1, row);
@@ -413,8 +434,22 @@ impl Gate {
             }
             CZ => {
                 if let (Some(v1), Some(v2)) = (
-                    Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Rational::zero()),
-                    Gate::add_spider(graph, qs, self.qs[1], VType::Z, EType::N, Rational::zero()),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[0],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[1],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
                 ) {
                     let row = max(graph.row(v1), graph.row(v2));
                     graph.set_row(v1, row);
@@ -426,8 +461,22 @@ impl Gate {
             }
             XCX => {
                 if let (Some(v1), Some(v2)) = (
-                    Gate::add_spider(graph, qs, self.qs[0], VType::X, EType::N, Rational::zero()),
-                    Gate::add_spider(graph, qs, self.qs[1], VType::X, EType::N, Rational::zero()),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[0],
+                        VType::X,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[1],
+                        VType::X,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
                 ) {
                     let row = max(graph.row(v1), graph.row(v2));
                     graph.set_row(v1, row);
@@ -439,16 +488,44 @@ impl Gate {
             }
             SWAP => {
                 if let (Some(v1), Some(v2)) = (
-                    Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Rational::zero()),
-                    Gate::add_spider(graph, qs, self.qs[1], VType::Z, EType::N, Rational::zero()),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[0],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[1],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    ),
                 ) {
                     let row = max(graph.row(v1), graph.row(v2));
                     graph.set_row(v1, row);
                     graph.set_row(v2, row);
 
                     qs.swap(self.qs[0], self.qs[1]);
-                    Gate::add_spider(graph, qs, self.qs[0], VType::Z, EType::N, Rational::zero());
-                    Gate::add_spider(graph, qs, self.qs[1], VType::Z, EType::N, Rational::zero());
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[0],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    );
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[1],
+                        VType::Z,
+                        EType::N,
+                        Rational64::zero(),
+                    );
                 }
             }
             InitAncilla => {
@@ -464,7 +541,14 @@ impl Gate {
                 }
             }
             PostSelect => {
-                Gate::add_spider(graph, qs, self.qs[0], VType::X, EType::N, Rational::zero());
+                Gate::add_spider(
+                    graph,
+                    qs,
+                    self.qs[0],
+                    VType::X,
+                    EType::N,
+                    Rational64::zero(),
+                );
                 graph.scalar_mut().mul_sqrt2_pow(-1);
 
                 // all later gates involving this qubit are quietly ignored
@@ -483,9 +567,23 @@ impl Gate {
             }
             TOFF => {
                 if postselect {
-                    Gate::add_spider(graph, qs, self.qs[2], VType::Z, EType::H, Rational::zero());
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[2],
+                        VType::Z,
+                        EType::H,
+                        Rational64::zero(),
+                    );
                     Gate::add_ccz_postselected(graph, qs, &self.qs);
-                    Gate::add_spider(graph, qs, self.qs[2], VType::Z, EType::H, Rational::zero());
+                    Gate::add_spider(
+                        graph,
+                        qs,
+                        self.qs[2],
+                        VType::Z,
+                        EType::H,
+                        Rational64::zero(),
+                    );
                 } else {
                     let mut c = Circuit::new(0);
                     self.push_basic_gates(&mut c);

--- a/quizx/src/generate.rs
+++ b/quizx/src/generate.rs
@@ -18,7 +18,7 @@ use std::mem;
 
 use crate::circuit::*;
 use crate::gate::*;
-use num::Rational;
+use num::Rational64;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
@@ -353,7 +353,7 @@ impl RandomPauliGadgetCircuitBuilder {
                     1 => lc.push(Gate::new(HAD, vec![q])),
                     2 => {
                         let mut g = Gate::new(XPhase, vec![q]);
-                        g.phase = Rational::new(1, 2);
+                        g.phase = Rational64::new(1, 2);
                         lc.push(g);
                     }
                     _ => {}
@@ -381,7 +381,7 @@ impl RandomPauliGadgetCircuitBuilder {
             };
 
             let mut g = Gate::new(ParityPhase, qs);
-            g.phase = Rational::new(phase_num as isize, self.phase_denom as isize);
+            g.phase = Rational64::new(phase_num as i64, self.phase_denom as i64);
 
             // add pauli gadget to the circuit
             c += &lc;

--- a/quizx/src/graph.rs
+++ b/quizx/src/graph.rs
@@ -137,6 +137,7 @@ impl<'a> Iterator for VIter<'a> {
 
 impl<'a> ExactSizeIterator for VIter<'a> {}
 
+#[allow(clippy::type_complexity)]
 pub enum EIter<'a> {
     Vec(
         usize,

--- a/quizx/src/graph.rs
+++ b/quizx/src/graph.rs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 use crate::scalar::*;
-use num::rational::Rational;
+use num::rational::Rational64;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::iter::FromIterator;
 
@@ -32,7 +32,7 @@ pub enum VType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct VData {
     pub ty: VType,
-    pub phase: Rational,
+    pub phase: Rational64,
     pub qubit: i32,
     pub row: i32,
 }
@@ -70,11 +70,11 @@ pub enum BasisElem {
 }
 
 impl BasisElem {
-    pub fn phase(&self) -> Rational {
+    pub fn phase(&self) -> Rational64 {
         if *self == BasisElem::Z1 || *self == BasisElem::X1 {
-            Rational::one()
+            Rational64::one()
         } else {
-            Rational::zero()
+            Rational64::zero()
         }
     }
 
@@ -341,9 +341,9 @@ pub trait GraphLike: Clone + Sized + Send + Sync + std::fmt::Debug {
     /// Behaviour is undefined if there is no edge between s and t.
     fn remove_edge(&mut self, s: V, t: V);
 
-    fn set_phase(&mut self, v: V, phase: Rational);
-    fn phase(&self, v: V) -> Rational;
-    fn add_to_phase(&mut self, v: V, phase: Rational);
+    fn set_phase(&mut self, v: V, phase: Rational64);
+    fn phase(&self, v: V) -> Rational64;
+    fn add_to_phase(&mut self, v: V, phase: Rational64);
     fn set_vertex_type(&mut self, v: V, ty: VType);
     fn vertex_type(&self, v: V) -> VType;
     fn vertex_data(&self, v: V) -> VData;
@@ -409,7 +409,7 @@ pub trait GraphLike: Clone + Sized + Send + Sync + std::fmt::Debug {
         }
     }
 
-    fn add_vertex_with_phase(&mut self, ty: VType, phase: Rational) -> V {
+    fn add_vertex_with_phase(&mut self, ty: VType, phase: Rational64) -> V {
         let v = self.add_vertex(ty);
         self.set_phase(v, phase);
         v
@@ -424,7 +424,7 @@ pub trait GraphLike: Clone + Sized + Send + Sync + std::fmt::Debug {
         if s == t {
             if st == VType::Z || st == VType::X {
                 if ety == EType::H {
-                    self.add_to_phase(s, Rational::new(1, 1));
+                    self.add_to_phase(s, Rational64::new(1, 1));
                     self.scalar_mut().mul_sqrt2_pow(-1);
                 }
             } else {
@@ -442,11 +442,11 @@ pub trait GraphLike: Clone + Sized + Send + Sync + std::fmt::Debug {
                         }
                         (EType::H, EType::N) => {
                             self.set_edge_type(s, t, EType::N);
-                            self.add_to_phase(s, Rational::new(1, 1));
+                            self.add_to_phase(s, Rational64::new(1, 1));
                             self.scalar_mut().mul_sqrt2_pow(-1);
                         }
                         (EType::N, EType::H) => {
-                            self.add_to_phase(s, Rational::new(1, 1));
+                            self.add_to_phase(s, Rational64::new(1, 1));
                             self.scalar_mut().mul_sqrt2_pow(-1);
                         }
                     }
@@ -459,11 +459,11 @@ pub trait GraphLike: Clone + Sized + Send + Sync + std::fmt::Debug {
                         }
                         (EType::N, EType::H) => {
                             self.set_edge_type(s, t, EType::H);
-                            self.add_to_phase(s, Rational::new(1, 1));
+                            self.add_to_phase(s, Rational64::new(1, 1));
                             self.scalar_mut().mul_sqrt2_pow(-1);
                         }
                         (EType::H, EType::N) => {
-                            self.add_to_phase(s, Rational::new(1, 1));
+                            self.add_to_phase(s, Rational64::new(1, 1));
                             self.scalar_mut().mul_sqrt2_pow(-1);
                         }
                         (EType::H, EType::H) => {} // ignore new edge

--- a/quizx/src/hash_graph.rs
+++ b/quizx/src/hash_graph.rs
@@ -226,8 +226,7 @@ impl GraphLike for Graph {
         self.edata
             .get(&s)
             .expect("Source vertex not found")
-            .get(&t)
-            .map(|x| *x)
+            .get(&t).copied()
     }
 
     fn set_coord(&mut self, v: V, coord: (i32, i32)) {
@@ -295,13 +294,7 @@ impl GraphLike for Graph {
     where
         F: Fn(V) -> bool,
     {
-        for &v in self.vdata.keys() {
-            if f(v) {
-                return Some(v);
-            }
-        }
-
-        None
+        self.vdata.keys().find(|&&v| f(v)).copied()
     }
 
     fn contains_vertex(&self, v: V) -> bool {

--- a/quizx/src/hash_graph.rs
+++ b/quizx/src/hash_graph.rs
@@ -16,7 +16,7 @@
 
 pub use crate::graph::*;
 use crate::scalar::*;
-use num::rational::Rational;
+use num::rational::Rational64;
 use rustc_hash::FxHashMap;
 use std::iter::FromIterator;
 
@@ -133,7 +133,7 @@ impl GraphLike for Graph {
     fn add_vertex(&mut self, ty: VType) -> V {
         self.add_vertex_with_data(VData {
             ty,
-            phase: Rational::new(0, 1),
+            phase: Rational64::new(0, 1),
             qubit: 0,
             row: 0,
         })
@@ -179,15 +179,15 @@ impl GraphLike for Graph {
         self.remove_half_edge(t, s);
     }
 
-    fn set_phase(&mut self, v: V, phase: Rational) {
+    fn set_phase(&mut self, v: V, phase: Rational64) {
         self.vdata.get_mut(&v).expect("Vertex not found").phase = phase.mod2();
     }
 
-    fn phase(&self, v: V) -> Rational {
+    fn phase(&self, v: V) -> Rational64 {
         self.vdata.get(&v).expect("Vertex not found").phase
     }
 
-    fn add_to_phase(&mut self, v: V, phase: Rational) {
+    fn add_to_phase(&mut self, v: V, phase: Rational64) {
         if let Some(d) = self.vdata.get_mut(&v) {
             d.phase = (d.phase + phase).mod2();
         } else {
@@ -226,7 +226,8 @@ impl GraphLike for Graph {
         self.edata
             .get(&s)
             .expect("Source vertex not found")
-            .get(&t).copied()
+            .get(&t)
+            .copied()
     }
 
     fn set_coord(&mut self, v: V, coord: (i32, i32)) {

--- a/quizx/src/linalg.rs
+++ b/quizx/src/linalg.rs
@@ -354,6 +354,7 @@ impl std::ops::IndexMut<usize> for Mat2 {
 impl<'a, 'b> std::ops::Mul<&'b Mat2> for &'a Mat2 {
     type Output = Mat2;
 
+    #[allow(clippy::suspicious_arithmetic_impl)]
     fn mul(self, rhs: &Mat2) -> Self::Output {
         if self.num_cols() != rhs.num_rows() {
             panic!("Cannot multiply matrices with mismatched dimensions.");

--- a/quizx/src/linalg.rs
+++ b/quizx/src/linalg.rs
@@ -89,7 +89,7 @@ impl Mat2 {
     }
 
     pub fn num_cols(&self) -> usize {
-        if self.d.len() > 0 {
+        if !self.d.is_empty() {
             self.d[0].len()
         } else {
             0
@@ -213,24 +213,18 @@ impl Mat2 {
                     }
                 }
 
-                loop {
-                    if let Some(&pcol) = pivot_cols1.last() {
-                        if i0 > pcol || pcol >= i1 {
-                            break;
-                        }
-                        pivot_cols1.pop();
-                        for r in 0..pivot_row {
-                            if self.d[r][pcol] != 0 {
-                                self.row_add(pivot_row, r);
-                                x.row_add(pivot_row, r);
-                            }
-                        }
-                        if pivot_row > 0 {
-                            pivot_row -= 1;
-                        }
-                    } else {
+                while let Some(&pcol) = pivot_cols1.last() {
+                    if i0 > pcol || pcol >= i1 {
                         break;
                     }
+                    pivot_cols1.pop();
+                    for r in 0..pivot_row {
+                        if self.d[r][pcol] != 0 {
+                            self.row_add(pivot_row, r);
+                            x.row_add(pivot_row, r);
+                        }
+                    }
+                    pivot_row = pivot_row.saturating_sub(1);
                 }
             }
         }
@@ -295,7 +289,7 @@ impl Mat2 {
 impl RowOps for Mat2 {
     fn row_add(&mut self, r0: usize, r1: usize) {
         for i in 0..self.num_cols() {
-            self.d[r1][i] = self.d[r0][i] ^ self.d[r1][i];
+            self.d[r1][i] ^= self.d[r0][i];
         }
     }
 
@@ -307,7 +301,7 @@ impl RowOps for Mat2 {
 impl ColOps for Mat2 {
     fn col_add(&mut self, c0: usize, c1: usize) {
         for i in 0..self.num_rows() {
-            self.d[i][c1] = self.d[i][c0] ^ self.d[i][c1];
+            self.d[i][c1] ^= self.d[i][c0];
         }
     }
 
@@ -325,7 +319,7 @@ impl fmt::Display for Mat2 {
             for x in row {
                 write!(f, "{} ", x)?;
             }
-            write!(f, "]\n")?;
+            writeln!(f, "]")?;
         }
         Ok(())
     }
@@ -369,7 +363,7 @@ impl<'a, 'b> std::ops::Mul<&'b Mat2> for &'a Mat2 {
         Mat2::build(self.num_rows(), rhs.num_cols(), |x, y| {
             let mut b = 0;
             for i in 0..k {
-                b = b ^ (self.d[x][i] & rhs.d[i][y]);
+                b ^= self.d[x][i] & rhs.d[i][y];
             }
             b == 1
         })

--- a/quizx/src/random_graph.rs
+++ b/quizx/src/random_graph.rs
@@ -1,5 +1,5 @@
 use crate::graph::*;
-use num::Rational;
+use num::Rational64;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
@@ -38,7 +38,7 @@ impl EquatorialStabilizerStateBuilder {
         let mut num_cz = 0;
         for i in 0..self.qubits {
             g.add_edge(spiders[i], outputs[i]);
-            g.set_phase(spiders[i], Rational::new(self.rng.gen_range(0..3), 2));
+            g.set_phase(spiders[i], Rational64::new(self.rng.gen_range(0..3), 2));
 
             for j in 0..i {
                 if self.rng.gen_bool(0.5) {

--- a/quizx/src/random_graph.rs
+++ b/quizx/src/random_graph.rs
@@ -8,6 +8,12 @@ pub struct EquatorialStabilizerStateBuilder {
     pub qubits: usize,
 }
 
+impl Default for EquatorialStabilizerStateBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EquatorialStabilizerStateBuilder {
     pub fn new() -> EquatorialStabilizerStateBuilder {
         EquatorialStabilizerStateBuilder {

--- a/quizx/src/scalar.rs
+++ b/quizx/src/scalar.rs
@@ -196,7 +196,7 @@ impl<T: Coeffs> Scalar<T> {
                     }
 
                     for i in 0..coeffs.len() {
-                        coeffs[i] = coeffs[i] >> 1;
+                        coeffs[i] >>= 1;
                     }
                     *pow += 1;
                 }
@@ -303,7 +303,7 @@ impl<T: Coeffs> FromPhase for Scalar<T> {
                 rdenom *= pad as isize;
                 rnumer = rnumer.rem_euclid(2 * rdenom);
                 let sgn = if rnumer >= rdenom {
-                    rnumer = rnumer - rdenom;
+                    rnumer -= rdenom;
                     -1
                 } else {
                     1
@@ -396,7 +396,7 @@ impl<'a, 'b, T: Coeffs> std::ops::Mul<&'b Scalar<T>> for &'a Scalar<T> {
                                 if pos < lcm {
                                     coeffs[pos] += coeffs0[i] * coeffs1[j];
                                 } else {
-                                    coeffs[pos - lcm] += -1 * coeffs0[i] * coeffs1[j];
+                                    coeffs[pos - lcm] += -coeffs0[i] * coeffs1[j];
                                 }
                             }
                         }
@@ -431,7 +431,7 @@ impl<'a, T: Coeffs> std::ops::Mul<&'a Scalar<T>> for Scalar<T> {
 }
 
 /// Implements *=
-impl<'a, T: Coeffs> std::ops::MulAssign<Scalar<T>> for Scalar<T> {
+impl<T: Coeffs> std::ops::MulAssign<Scalar<T>> for Scalar<T> {
     fn mul_assign(&mut self, rhs: Scalar<T>) {
         *self = &*self * &rhs;
     }

--- a/quizx/src/scalar.rs
+++ b/quizx/src/scalar.rs
@@ -88,10 +88,22 @@ pub trait Sqrt2: Sized {
 /// matrices, because they have to implement Copy (the size must be
 /// known at compile time).
 pub trait Coeffs: Clone + std::ops::IndexMut<usize, Output = isize> {
-    fn len(&self) -> usize;
+    /// Returns a coefficient list representing the number 0.
     fn zero() -> Self;
+
+    /// Returns a coefficient list representing the number 1.
     fn one() -> Self;
+
+    /// Create a new list of coefficients of size sz.
     fn new(sz: usize) -> Option<(Self, usize)>;
+
+    /// Returns the length of the coefficient list.
+    fn len(&self) -> usize;
+
+    /// Returns true if the coefficient list is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Implement Copy whenever our coefficient list allows us to.

--- a/quizx/src/scalar.rs
+++ b/quizx/src/scalar.rs
@@ -16,7 +16,7 @@
 
 use approx::AbsDiffEq;
 use num::complex::Complex;
-use num::rational::Rational;
+use num::rational::Rational64;
 pub use num::traits::identities::{One, Zero};
 use num::{integer, Integer};
 use std::cmp::min;
@@ -54,19 +54,19 @@ pub trait Mod2 {
     fn mod2(&self) -> Self;
 }
 
-impl Mod2 for Rational {
-    fn mod2(&self) -> Rational {
+impl Mod2 for Rational64 {
+    fn mod2(&self) -> Rational64 {
         let mut num = self.numer().rem_euclid(2 * *self.denom());
         if num > *self.denom() {
             num -= 2 * *self.denom();
         }
-        Rational::new(num, *self.denom())
+        Rational64::new(num, *self.denom())
     }
 }
 
 /// Produce a number from rational root of -1.
 pub trait FromPhase {
-    fn from_phase(p: Rational) -> Self;
+    fn from_phase(p: Rational64) -> Self;
     fn minus_one() -> Self;
 }
 
@@ -158,7 +158,7 @@ impl<T: Coeffs> Scalar<T> {
         *self *= Scalar::sqrt2_pow(p);
     }
 
-    pub fn mul_phase(&mut self, phase: Rational) {
+    pub fn mul_phase(&mut self, phase: Rational64) {
         *self *= Scalar::from_phase(phase);
     }
 
@@ -166,7 +166,7 @@ impl<T: Coeffs> Scalar<T> {
         Float(self.float_value())
     }
 
-    pub fn one_plus_phase(p: Rational) -> Scalar<T> {
+    pub fn one_plus_phase(p: Rational64) -> Scalar<T> {
         Scalar::one() + Scalar::from_phase(p)
     }
 
@@ -306,13 +306,13 @@ impl<T: Coeffs> Sqrt2 for Scalar<T> {
 }
 
 impl<T: Coeffs> FromPhase for Scalar<T> {
-    fn from_phase(p: Rational) -> Scalar<T> {
+    fn from_phase(p: Rational64) -> Scalar<T> {
         let mut rnumer = *p.numer();
         let mut rdenom = *p.denom();
         match T::new(rdenom as usize) {
             Some((mut coeffs, pad)) => {
-                rnumer *= pad as isize;
-                rdenom *= pad as isize;
+                rnumer *= pad as i64;
+                rdenom *= pad as i64;
                 rnumer = rnumer.rem_euclid(2 * rdenom);
                 let sgn = if rnumer >= rdenom {
                     rnumer -= rdenom;
@@ -331,7 +331,7 @@ impl<T: Coeffs> FromPhase for Scalar<T> {
     }
 
     fn minus_one() -> Scalar<T> {
-        Scalar::from_phase(Rational::one())
+        Scalar::from_phase(Rational64::one())
     }
 }
 
@@ -680,33 +680,33 @@ mod tests {
     #[test]
     fn phases() {
         let s: ScalarN =
-            ScalarN::from_phase(Rational::new(4, 3)) * ScalarN::from_phase(Rational::new(2, 5));
-        let t: ScalarN = ScalarN::from_phase(Rational::new(4, 3) + Rational::new(2, 5));
+            ScalarN::from_phase(Rational64::new(4, 3)) * ScalarN::from_phase(Rational64::new(2, 5));
+        let t: ScalarN = ScalarN::from_phase(Rational64::new(4, 3) + Rational64::new(2, 5));
         assert_abs_diff_eq!(s, t);
 
-        assert_abs_diff_eq!(Scalar4::from_phase(Rational::new(0, 1)), Scalar4::one());
+        assert_abs_diff_eq!(Scalar4::from_phase(Rational64::new(0, 1)), Scalar4::one());
         assert_abs_diff_eq!(
-            Scalar4::from_phase(Rational::new(1, 1)),
+            Scalar4::from_phase(Rational64::new(1, 1)),
             Scalar4::real(-1.0)
         );
         assert_abs_diff_eq!(
-            Scalar4::from_phase(Rational::new(1, 2)),
+            Scalar4::from_phase(Rational64::new(1, 2)),
             Scalar4::complex(0.0, 1.0)
         );
         assert_abs_diff_eq!(
-            Scalar4::from_phase(Rational::new(-1, 2)),
+            Scalar4::from_phase(Rational64::new(-1, 2)),
             Scalar4::complex(0.0, -1.0)
         );
         assert_abs_diff_eq!(
-            Scalar4::from_phase(Rational::new(1, 4)),
+            Scalar4::from_phase(Rational64::new(1, 4)),
             Scalar4::from_int_coeffs(&[0, 1, 0, 0])
         );
         assert_abs_diff_eq!(
-            Scalar4::from_phase(Rational::new(3, 4)),
+            Scalar4::from_phase(Rational64::new(3, 4)),
             Scalar4::from_int_coeffs(&[0, 0, 0, 1])
         );
         assert_abs_diff_eq!(
-            Scalar4::from_phase(Rational::new(7, 4)),
+            Scalar4::from_phase(Rational64::new(7, 4)),
             Scalar4::from_int_coeffs(&[0, 0, 0, -1])
         );
     }
@@ -739,12 +739,12 @@ mod tests {
     #[test]
     fn one_plus_phases() {
         assert_abs_diff_eq!(
-            ScalarN::one_plus_phase(Rational::new(1, 1)),
+            ScalarN::one_plus_phase(Rational64::new(1, 1)),
             ScalarN::zero()
         );
 
-        let plus = ScalarN::one_plus_phase(Rational::new(1, 2));
-        let minus = ScalarN::one_plus_phase(Rational::new(-1, 2));
+        let plus = ScalarN::one_plus_phase(Rational64::new(1, 2));
+        let minus = ScalarN::one_plus_phase(Rational64::new(-1, 2));
         assert_abs_diff_eq!(plus * minus, Scalar::real(2.0));
     }
 

--- a/quizx/src/scalar.rs
+++ b/quizx/src/scalar.rs
@@ -669,11 +669,8 @@ mod tests {
     fn mul_same_base() {
         let s = Scalar4::from_int_coeffs(&[1, 2, 3, 4]);
         let t = Scalar4::from_int_coeffs(&[4, 5, 6, 7]);
-        let st = &s * &t;
-        assert!(match st {
-            Exact(_, _) => true,
-            _ => false,
-        });
+        let st = s * t;
+        assert!(matches!(st, Exact(_, _)));
         assert_abs_diff_eq!(st.to_float(), s.to_float() * t.to_float());
     }
 
@@ -753,7 +750,7 @@ mod tests {
         let p1 = Scalar4::sqrt2_pow(200);
         let p2 = Scalar4::sqrt2_pow(-200);
         // multiplying small, large, and/or very different powers of 2 is ok
-        let p3 = &p1 * &p2;
+        let p3 = p1 * p2;
         assert_eq!(p3, Scalar4::one());
     }
 
@@ -763,11 +760,11 @@ mod tests {
         let p2 = Scalar4::sqrt2_pow(210);
         // adding large or small powers of 2 is ok, as long as they are fairly
         // close
-        let p3 = &p1 + &p2;
+        let p3 = p1 + p2;
 
         let q1 = Scalar4::one();
         let q2 = Scalar4::sqrt2_pow(10);
-        let q3 = Scalar4::sqrt2_pow(200) * (&q1 + &q2);
+        let q3 = Scalar4::sqrt2_pow(200) * (q1 + q2);
 
         assert_eq!(p3, q3);
     }
@@ -778,7 +775,7 @@ mod tests {
         let p1 = Scalar4::sqrt2_pow(200);
         let p2 = Scalar4::sqrt2_pow(-200);
         // adding very different powers of 2 will panic
-        let p3 = &p1 + &p2;
+        let p3 = p1 + p2;
         assert_eq!(p3, Scalar4::one());
     }
 
@@ -799,7 +796,7 @@ mod tests {
             assert_abs_diff_eq!(lhs.re, rhs.re, epsilon = 0.00001);
             assert_abs_diff_eq!(lhs.im, rhs.im, epsilon = 0.00001);
 
-            let abs = &p * &p_conj;
+            let abs = p * p_conj;
             let absf = abs.float_value();
             println!("p = {:?}", p);
             println!("p_conj = {:?}", p_conj);

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -196,10 +196,10 @@ pub fn fuse_gadgets(g: &mut impl GraphLike) -> bool {
             let degree = vs.len() as i32;
             fused = true;
             let mut ph = Rational::zero();
-            for i in 1..gs.len() {
-                ph += g.phase(gs[i].1);
-                g.remove_vertex(gs[i].0);
-                g.remove_vertex(gs[i].1);
+            for (u, v) in gs.iter().copied() {
+                ph += g.phase(v);
+                g.remove_vertex(u);
+                g.remove_vertex(v);
             }
 
             g.add_to_phase(gs[0].1, ph);

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -16,7 +16,7 @@
 
 use crate::basic_rules::*;
 use crate::graph::*;
-use num::{One, Rational, Zero};
+use num::{One, Rational64, Zero};
 use rustc_hash::FxHashMap;
 
 /// Repeatedly apply the given rule at any vertex
@@ -195,7 +195,7 @@ pub fn fuse_gadgets(g: &mut impl GraphLike) -> bool {
             let num = gs.len() as i32;
             let degree = vs.len() as i32;
             fused = true;
-            let mut ph = Rational::zero();
+            let mut ph = Rational64::zero();
             for (u, v) in gs.iter().copied() {
                 ph += g.phase(v);
                 g.remove_vertex(u);

--- a/quizx/src/tensor.rs
+++ b/quizx/src/tensor.rs
@@ -153,7 +153,7 @@ impl<A: TensorElem> CompareTensors for Tensor<A> {
                 }
                 // if they are different, we cross-multiply to check scalar equivalence
                 else {
-                    t0 * b1.clone() == t1 * b0.clone()
+                    t0 * *b1 == t1 * *b0
                 }
             }
             // all-zero tensors of the same dimension are equal

--- a/quizx/src/tensor.rs
+++ b/quizx/src/tensor.rs
@@ -21,11 +21,11 @@ use crate::scalar::*;
 use ndarray::parallel::prelude::*;
 use ndarray::prelude::*;
 use ndarray::*;
-use num::{Complex, Rational};
+use num::{Complex, Rational64};
 use rustc_hash::FxHashMap;
 use std::collections::VecDeque;
-use std::iter::FromIterator;
 use std::convert::TryFrom;
+use std::iter::FromIterator;
 
 /// Generic tensor type used by quizx
 pub type Tensor<A> = Array<A, IxDyn>;
@@ -48,13 +48,13 @@ impl Sqrt2 for Complex<f64> {
 }
 
 impl FromPhase for Complex<f64> {
-    fn from_phase(p: Rational) -> Complex<f64> {
+    fn from_phase(p: Rational64) -> Complex<f64> {
         let exp = (*p.numer() as f64) / (*p.denom() as f64);
         Complex::new(-1.0, 0.0).powf(exp)
     }
 
     fn minus_one() -> Complex<f64> {
-        Self::from_phase(Rational::one())
+        Self::from_phase(Rational64::one())
     }
 }
 
@@ -113,10 +113,10 @@ pub trait ToTensor {
 pub trait QubitOps<A: TensorElem> {
     fn ident(q: usize) -> Self;
     fn delta(q: usize) -> Self;
-    fn cphase(p: Rational, q: usize) -> Self;
+    fn cphase(p: Rational64, q: usize) -> Self;
     fn hadamard() -> Self;
     fn delta_at(&mut self, qs: &[usize]);
-    fn cphase_at(&mut self, p: Rational, qs: &[usize]);
+    fn cphase_at(&mut self, p: Rational64, qs: &[usize]);
     fn hadamard_at(&mut self, i: usize);
 
     /// split into two non-overlapping pieces, where index q=0 and q=1
@@ -219,7 +219,7 @@ impl<A: TensorElem> QubitOps<A> for Tensor<A> {
         })
     }
 
-    fn cphase(p: Rational, q: usize) -> Tensor<A> {
+    fn cphase(p: Rational64, q: usize) -> Tensor<A> {
         let mut t = Tensor::ident(q);
         let qs: Vec<_> = (0..q).collect();
         t.cphase_at(p, &qs);
@@ -228,7 +228,7 @@ impl<A: TensorElem> QubitOps<A> for Tensor<A> {
 
     fn hadamard() -> Tensor<A> {
         let n = A::one_over_sqrt2();
-        let minus = A::from_phase(Rational::one());
+        let minus = A::from_phase(Rational64::one());
         array![[n, n], [n, minus * n]].into_dyn()
     }
 
@@ -243,7 +243,7 @@ impl<A: TensorElem> QubitOps<A> for Tensor<A> {
         *self *= &del;
     }
 
-    fn cphase_at(&mut self, p: Rational, qs: &[usize]) {
+    fn cphase_at(&mut self, p: Rational64, qs: &[usize]) {
         let mut shape: Vec<usize> = vec![1; self.ndim()];
         for &q in qs {
             shape[q] = 2;
@@ -262,7 +262,7 @@ impl<A: TensorElem> QubitOps<A> for Tensor<A> {
 
     fn hadamard_at(&mut self, q: usize) {
         let n = A::one_over_sqrt2();
-        let minus = A::from_phase(Rational::one()); // -1 = e^(i pi)
+        let minus = A::from_phase(Rational64::one()); // -1 = e^(i pi)
 
         // split into two non-overlapping pieces, where index q=0 and q=1
         let (mut ma, mut mb) = self.slice_qubit_mut(q);
@@ -361,7 +361,7 @@ impl<G: GraphLike + Clone> ToTensor for G {
                     if et == EType::N {
                         a.delta_at(&[0, wi]);
                     } else {
-                        a.cphase_at(Rational::one(), &[0, wi]);
+                        a.cphase_at(Rational64::one(), &[0, wi]);
                         // TODO incorporate with cphase_at
                         a *= A::one_over_sqrt2();
                         // num_had += 1;
@@ -401,15 +401,15 @@ impl ToTensor for Circuit {
         for g in self.gates.iter().rev() {
             match g.t {
                 ZPhase => a.cphase_at(g.phase, &g.qs),
-                Z | CZ | CCZ => a.cphase_at(Rational::one(), &g.qs),
-                S => a.cphase_at(Rational::new(1, 2), &g.qs),
-                T => a.cphase_at(Rational::new(1, 4), &g.qs),
-                Sdg => a.cphase_at(Rational::new(-1, 2), &g.qs),
-                Tdg => a.cphase_at(Rational::new(-1, 4), &g.qs),
+                Z | CZ | CCZ => a.cphase_at(Rational64::one(), &g.qs),
+                S => a.cphase_at(Rational64::new(1, 2), &g.qs),
+                T => a.cphase_at(Rational64::new(1, 4), &g.qs),
+                Sdg => a.cphase_at(Rational64::new(-1, 2), &g.qs),
+                Tdg => a.cphase_at(Rational64::new(-1, 4), &g.qs),
                 HAD => a.hadamard_at(g.qs[0]),
                 NOT => {
                     a.hadamard_at(g.qs[0]);
-                    a.cphase_at(Rational::one(), &g.qs);
+                    a.cphase_at(Rational64::one(), &g.qs);
                     a.hadamard_at(g.qs[0]);
                 }
                 XPhase => {
@@ -419,12 +419,12 @@ impl ToTensor for Circuit {
                 }
                 CNOT => {
                     a.hadamard_at(g.qs[1]);
-                    a.cphase_at(Rational::one(), &g.qs);
+                    a.cphase_at(Rational64::one(), &g.qs);
                     a.hadamard_at(g.qs[1]);
                 }
                 TOFF => {
                     a.hadamard_at(g.qs[2]);
-                    a.cphase_at(Rational::one(), &g.qs);
+                    a.cphase_at(Rational64::one(), &g.qs);
                     a.hadamard_at(g.qs[2]);
                 }
                 SWAP => a.swap_axes(g.qs[0], g.qs[1]),
@@ -532,7 +532,7 @@ mod tests {
         g.scalar_mut().mul_sqrt2_pow(1);
         let t = g.to_tensor4();
         println!("{}", t);
-        assert_eq!(t, Tensor::cphase(Rational::one(), 2));
+        assert_eq!(t, Tensor::cphase(Rational64::one(), 2));
     }
 
     #[test]

--- a/quizx/src/vec_graph.rs
+++ b/quizx/src/vec_graph.rs
@@ -16,7 +16,7 @@
 
 pub use crate::graph::*;
 use crate::scalar::*;
-use num::rational::Rational;
+use num::rational::Rational64;
 use std::mem;
 
 pub type VTab<T> = Vec<Option<T>>;
@@ -141,7 +141,7 @@ impl GraphLike for Graph {
     fn add_vertex(&mut self, ty: VType) -> V {
         self.add_vertex_with_data(VData {
             ty,
-            phase: Rational::new(0, 1),
+            phase: Rational64::new(0, 1),
             qubit: 0,
             row: 0,
         })
@@ -196,7 +196,7 @@ impl GraphLike for Graph {
         self.remove_half_edge(t, s);
     }
 
-    fn set_phase(&mut self, v: V, phase: Rational) {
+    fn set_phase(&mut self, v: V, phase: Rational64) {
         if let Some(Some(d)) = self.vdata.get_mut(v) {
             d.phase = phase.mod2();
         } else {
@@ -204,11 +204,11 @@ impl GraphLike for Graph {
         }
     }
 
-    fn phase(&self, v: V) -> Rational {
+    fn phase(&self, v: V) -> Rational64 {
         self.vdata[v].expect("Vertex not found").phase
     }
 
-    fn add_to_phase(&mut self, v: V, phase: Rational) {
+    fn add_to_phase(&mut self, v: V, phase: Rational64) {
         if let Some(Some(d)) = self.vdata.get_mut(v) {
             d.phase = (d.phase + phase).mod2();
         } else {

--- a/quizx/src/vec_graph.rs
+++ b/quizx/src/vec_graph.rs
@@ -43,11 +43,11 @@ impl Graph {
         }
     }
 
-    fn index<U>(nhd: &Vec<(V, U)>, v: V) -> Option<usize> {
+    fn index<U>(nhd: &[(V, U)], v: V) -> Option<usize> {
         nhd.iter().position(|&(v0, _)| v == v0)
     }
 
-    fn value<U: Copy>(nhd: &Vec<(V, U)>, v: V) -> Option<U> {
+    fn value<U: Copy>(nhd: &[(V, U)], v: V) -> Option<U> {
         for (v0, u) in nhd.iter() {
             if v == *v0 {
                 return Some(*u);
@@ -61,7 +61,7 @@ impl Graph {
     /// more efficient.
     fn remove_half_edge(&mut self, s: V, t: V) {
         if let Some(Some(nhd)) = self.edata.get_mut(s) {
-            Graph::index(&nhd, t).map(|i| nhd.swap_remove(i));
+            Graph::index(nhd, t).map(|i| nhd.swap_remove(i));
         }
     }
 
@@ -234,14 +234,14 @@ impl GraphLike for Graph {
 
     fn set_edge_type(&mut self, s: V, t: V, ety: EType) {
         if let Some(Some(nhd)) = self.edata.get_mut(s) {
-            let i = Graph::index(&nhd, t).expect("Edge not found");
+            let i = Graph::index(nhd, t).expect("Edge not found");
             nhd[i] = (t, ety);
         } else {
             panic!("Source vertex not found");
         }
 
         if let Some(Some(nhd)) = self.edata.get_mut(t) {
-            let i = Graph::index(&nhd, s).expect("Edge not found");
+            let i = Graph::index(nhd, s).expect("Edge not found");
             nhd[i] = (s, ety);
         } else {
             panic!("Target vertex not found");
@@ -250,7 +250,7 @@ impl GraphLike for Graph {
 
     fn edge_type_opt(&self, s: V, t: V) -> Option<EType> {
         if let Some(Some(nhd)) = self.edata.get(s) {
-            Graph::value(&nhd, t)
+            Graph::value(nhd, t)
         } else {
             None
         }


### PR DESCRIPTION
This PR fixes all the warnings produced by `cargo check` and `cargo clippy --all-targets --all-features`.