### PR TITLE
fix: Move rust bindings to a `quizx._quizx` submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a02a88a17e74cadbc8ce77855e1d6c8ad0ab82901a4a9b5046bd01c1c0bd95cd"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "a5eb0b6ecba38961f6f4bd6cd5906dfab3cd426ff37b2eed5771006aa31656f1"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "ba8a6e48a29b5d22e4fdaf132d8ba8d3203ee9f06362d48f244346902a594ec3"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "4e80493c5965f94a747d0782a607b2328a4eea5391327b152b00e2f3b001cede"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "fcd7d86f42004025200e12a6a8119bd878329e6fddef8178eaafa4e4b5906c5b"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ approx = "0.5.1"
 itertools = "0.12.1"
 ndarray = "0.15.6"
 openqasm = "0.1.2"
-pyo3 = { version = "0.20" }
+pyo3 = { version = "0.21" }
 rand = "0.8.3"
 rayon = "1.5.0"
 regex = "1.4.3"

--- a/pybindings/quizx/__init__.py
+++ b/pybindings/quizx/__init__.py
@@ -1,4 +1,4 @@
-import quizx  # type: ignore
+from . import _quizx
 from .graph import VecGraph
 from .circuit import Circuit
 from . import simplify
@@ -9,5 +9,5 @@ __all__ = ["VecGraph", "Circuit", "simplify", "Decomposer"]
 
 def extract_circuit(g):
     c = Circuit()
-    c._c = quizx.extract_circuit(g._g)
+    c._c = _quizx.extract_circuit(g._g)
     return c

--- a/pybindings/quizx/circuit.py
+++ b/pybindings/quizx/circuit.py
@@ -1,5 +1,4 @@
-import quizx  # type: ignore
-
+from . import _quizx
 from .graph import VecGraph
 
 
@@ -10,13 +9,13 @@ class Circuit:
     @staticmethod
     def load(circuitfile: str) -> "Circuit":
         c = Circuit()
-        c._c = quizx.Circuit.load(circuitfile)
+        c._c = _quizx.Circuit.load(circuitfile)
         return c
 
     @staticmethod
     def from_qasm(qasm: str) -> "Circuit":
         c = Circuit()
-        c._c = quizx.Circuit.from_qasm(qasm)
+        c._c = _quizx.Circuit.from_qasm(qasm)
         return c
 
     def to_qasm(self):

--- a/pybindings/quizx/decompose.py
+++ b/pybindings/quizx/decompose.py
@@ -1,18 +1,17 @@
 from typing import List, Optional
 
-import quizx  # type: ignore
-
+from . import _quizx
 from .graph import VecGraph
 
 
 class Decomposer(object):
-    _d: quizx.Decomposer
+    _d: _quizx.Decomposer
 
     def __init__(self, graph: Optional[VecGraph] = None):
         if graph is None:
-            self._d = quizx.Decomposer.empty()
+            self._d = _quizx.Decomposer.empty()
         else:
-            self._d = quizx.Decomposer(graph.get_raw_graph())
+            self._d = _quizx.Decomposer(graph.get_raw_graph())
 
     def graphs(self) -> List[VecGraph]:
         return [VecGraph(g) for g in self._d.graphs()]

--- a/pybindings/quizx/graph.py
+++ b/pybindings/quizx/graph.py
@@ -19,26 +19,26 @@ from typing import Tuple, Dict, Any, Optional
 from pyzx.graph.base import BaseGraph  # type: ignore
 from pyzx.utils import VertexType, EdgeType  # type: ignore
 
-import quizx  # type: ignore
+from . import _quizx
 
 
 class VecGraph(BaseGraph[int, Tuple[int, int]]):
     """Rust implementation of :class:`~graph.base.BaseGraph`, based on quizx::vec_graph::Graph."""
 
-    _g: quizx.VecGraph
+    _g: _quizx.VecGraph
     backend = "quizx-vec"
 
     # The documentation of what these methods do
     # can be found in base.BaseGraph
-    def __init__(self, rust_graph: Optional[quizx.VecGraph] = None):
+    def __init__(self, rust_graph: Optional[_quizx.VecGraph] = None):
         BaseGraph.__init__(self)
         if rust_graph:
             self._g = rust_graph
         else:
-            self._g = quizx.VecGraph()
+            self._g = _quizx.VecGraph()
         self._vdata: Dict[int, Any] = dict()
 
-    def get_raw_graph(self) -> quizx.VecGraph:
+    def get_raw_graph(self) -> _quizx.VecGraph:
         """Return the underlying Rust graph instance."""
         return self._g
 

--- a/pybindings/quizx/simplify.py
+++ b/pybindings/quizx/simplify.py
@@ -1,13 +1,13 @@
-import quizx
+from . import _quizx
 
 
 def interior_clifford_simp(g):
-    quizx.interior_clifford_simp(g._g)
+    _quizx.interior_clifford_simp(g._g)
 
 
 def clifford_simp(g):
-    quizx.clifford_simp(g._g)
+    _quizx.clifford_simp(g._g)
 
 
 def full_simp(g):
-    quizx.full_simp(g._g)
+    _quizx.full_simp(g._g)

--- a/pybindings/src/lib.rs
+++ b/pybindings/src/lib.rs
@@ -5,8 +5,7 @@ use quizx::extract::ToCircuit;
 use quizx::graph::*;
 
 #[pymodule]
-#[pyo3(name = "quizx")]
-fn libquizx(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _quizx(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(dummy, m)?)?;
     m.add_function(wrap_pyfunction!(interior_clifford_simp, m)?)?;
     m.add_function(wrap_pyfunction!(clifford_simp, m)?)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,5 +51,6 @@ homepage = "https://github.com/Quantomatic/quizx"
 repository = "https://github.com/Quantomatic/quizx"
 
 [tool.maturin]
+module-name = "quizx._quizx"
 manifest-path = "pybindings/Cargo.toml"
 python-source = "pybindings"

--- a/quizx/src/scalar.rs
+++ b/quizx/src/scalar.rs
@@ -83,7 +83,7 @@ pub trait Sqrt2: Sized {
 }
 
 /// A list of coefficients. We give this as a parameter to allow
-/// either fixed-size lists (e.g. [i32;4]) or dynamic ones (e.g.
+/// either fixed-size lists (e.g. `[i32;4]`) or dynamic ones (e.g.
 /// [Vec]\<i32\>). Only the former can be used in tensors and
 /// matrices, because they have to implement Copy (the size must be
 /// known at compile time).

--- a/scripts/add_estimates_hs.py
+++ b/scripts/add_estimates_hs.py
@@ -2,7 +2,7 @@
 
 import csv
 import sys
-from bigfloat import BigFloat, log10
+from bigfloat import BigFloat, log10  # type: ignore
 
 
 def terms(t):


### PR DESCRIPTION
- Updates `pyo3` to `0.21`
- Adds a `module-name` config to maturin, so now the rust bindings are available under `quizx._quizx` in the rest of the code.
  This is required to prevent name collisions with the python definitions.
  Previous to #18 the bindings where being defined as a separate `libquizx` library, but that causes problems when trying to generate wheels and publish a single package.