### PR TITLE
fix: gadget fusion

### DIFF
--- a/pybindings/src/lib.rs
+++ b/pybindings/src/lib.rs
@@ -14,6 +14,7 @@ fn _quizx(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(dummy, m)?)?;
     m.add_function(wrap_pyfunction!(interior_clifford_simp, m)?)?;
     m.add_function(wrap_pyfunction!(clifford_simp, m)?)?;
+    m.add_function(wrap_pyfunction!(fuse_gadgets, m)?)?;
     m.add_function(wrap_pyfunction!(full_simp, m)?)?;
     m.add_function(wrap_pyfunction!(extract_circuit, m)?)?;
     m.add_class::<VecGraph>()?;
@@ -37,6 +38,11 @@ fn interior_clifford_simp(g: &mut VecGraph) {
 #[pyfunction]
 fn clifford_simp(g: &mut VecGraph) {
     quizx::simplify::clifford_simp(&mut g.g);
+}
+
+#[pyfunction]
+fn fuse_gadgets(g: &mut VecGraph) {
+    quizx::simplify::fuse_gadgets(&mut g.g);
 }
 
 #[pyfunction]

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -379,4 +379,30 @@ mod tests {
         // assert_eq!(h.num_vertices(), 0);
         // assert_eq!(g.to_tensor4(), h.to_tensor4());
     }
+
+    #[test]
+    fn simp_gadget_fusion() {
+        let c = Circuit::from_qasm(
+            r#"
+            qreg q[2];
+            t q[0];
+            cx q[1], q[0];
+            t q[0];
+            cx q[1], q[0];
+            t q[0];
+            t q[1];
+        "#,
+        )
+        .unwrap();
+        let mut g: Graph = c.to_graph();
+        g.plug_inputs(&[BasisElem::X0; 2]);
+        g.plug_outputs(&[BasisElem::X0; 2]);
+
+        let h = g.clone();
+        clifford_simp(&mut g);
+        fuse_gadgets(&mut g);
+
+        println!("{}", g.to_dot());
+        assert_eq!(g.to_tensor4(), h.to_tensor4());
+    }
 }

--- a/quizx/src/simplify.rs
+++ b/quizx/src/simplify.rs
@@ -197,7 +197,7 @@ pub fn fuse_gadgets(g: &mut impl GraphLike) -> bool {
             let degree = vs.len() as i32;
             fused = true;
             let mut ph = Phase::zero();
-            for (u, v) in gs.iter().copied() {
+            for (u, v) in gs.iter().skip(1).copied() {
                 ph += g.phase(v);
                 g.remove_vertex(u);
                 g.remove_vertex(v);


### PR DESCRIPTION
Gadget fusion doesn't seem to work as it deletes all of the phase gadgets before trying to update the phase of the first gadget. The bug disappears when we leave the first phase gadget undeleted.

```python
import pyzx as zx

def to_quizx(p_g):
    r_g = zx.Graph(backend='quizx-vec')
    v_map = dict()
    for v in p_g.vertices():
        new_v = r_g.add_vertex(ty=p_g.type(v), qubit=p_g.qubit(v), row=p_g.row(v), phase=p_g.phase(v))
        v_map[v] = new_v

    for e in p_g.edges():
        new_e = (v_map[e[0]], v_map[e[1]])
        r_g.add_edge(new_e, p_g.edge_type(e))
    return r_g

c = zx.Circuit(2)
c.add_gate("ZPhase", 0, 0.25)
c.add_gate("CNOT", 1, 0)
c.add_gate("ZPhase", 0, 0.25)
c.add_gate("CNOT", 1, 0)
c.add_gate("ZPhase", 0, 0.25)
c.add_gate("ZPhase", 1, 0.25)

g = c.to_graph()
g.apply_state('++')
g.apply_effect('++')

zx.draw(g, labels=True)
zx.clifford_simp(g)
zx.draw(g, labels=True)

r_g = to_quizx(g)

qzx.simplify.full_simp(r_g)
```

<img width="294" alt="image" src="https://github.com/Quantomatic/quizx/assets/13847804/93836f5e-f09d-4a55-89fc-21308a5de005">

```python
---------------------------------------------------------------------------
PanicException                            Traceback (most recent call last)
Cell In[6], line 33
     29 zx.draw(g, labels=True)
     31 r_g = to_quizx(g)
---> 33 qzx.simplify.full_simp(r_g)
     34 zx.draw(r_g, labels=True)

File ~/Documents/work/quizx/pybindings/quizx/simplify.py:13, in full_simp(g)
     12 def full_simp(g):
---> 13     _quizx.full_simp(g._g)

PanicException: Vertex not found 2
```