### PR TITLE
fix: bug in cutrank caching

### DIFF
--- a/pybindings/src/rankwidth.rs
+++ b/pybindings/src/rankwidth.rs
@@ -107,6 +107,11 @@ impl PyDecompTree {
         self.0.clear_rank(edge)
     }
 
+    /// Clear ranks of all edges
+    fn clear_ranks(&mut self) {
+        self.0.clear_ranks()
+    }
+
     /// Get the rank of an edge
     fn rank(&mut self, edge: (usize, usize)) -> Option<usize> {
         self.0.rank(edge)

--- a/quizx/src/rankwidth/decomp_tree.rs
+++ b/quizx/src/rankwidth/decomp_tree.rs
@@ -245,6 +245,10 @@ impl DecompTree {
         self.ranks.insert(e, rank);
     }
 
+    pub fn clear_ranks(&mut self) {
+        self.ranks.clear();
+    }
+
     pub fn clear_rank(&mut self, e: (usize, usize)) {
         let e = if e.0 < e.1 { e } else { (e.1, e.0) };
         self.ranks.remove(&e);
@@ -300,11 +304,13 @@ impl DecompTree {
 
         self.move_subtree(&path);
 
-        let mut x = path[0];
-        for &y in &path[1..] {
-            self.clear_rank((x, y));
-            x = y;
-        }
+        // TODO: only clear ranks that may have changed
+        self.clear_ranks();
+        // let mut x = path[0];
+        // for &y in &path[1..] {
+        //     self.clear_rank((x, y));
+        //     x = y;
+        // }
     }
 
     pub fn random_local_swap(&mut self, rng: &mut impl rand::Rng) {

--- a/scratchpads/ak.ipynb
+++ b/scratchpads/ak.ipynb
@@ -13,7 +13,86 @@
     "\n",
     "sys.path.insert(0, os.path.expanduser(\"~/git/pyzx\"))  # git version\n",
     "import quizx\n",
-    "import pyzx"
+    "import pyzx as zx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de32b40a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[4, [[1, [2, 3]], 0]]\n",
+      "2\n",
+      "[4, [[1, [2, 3]], 0]]\n",
+      "2\n",
+      "DecompTree(nodes=8, leaves=5, interior=3)\n",
+      "DecompTree(nodes=8, leaves=5, interior=3)\n",
+      "True\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "random.seed(42)\n",
+    "def gen_graph(n, m):\n",
+    "    g = zx.Graph()\n",
+    "    for _ in range(n):\n",
+    "        g.add_vertex(zx.VertexType.Z, phase=random.randint(0, 7) / 4)\n",
+    "    while g.num_edges() < m:\n",
+    "        [u, v] = random.sample(range(n), k=2)\n",
+    "        if (u, v) not in g.edge_set() and (v, u) not in g.edge_set():\n",
+    "            g.add_edge((u, v), zx.EdgeType.HADAMARD)\n",
+    "    return g\n",
+    "\n",
+    " \n",
+    "\n",
+    "g = gen_graph(5, 7)\n",
+    "g2 = quizx.VecGraph()\n",
+    "g2.add_vertices(g.num_vertices())\n",
+    "for u, v in g.edge_set():\n",
+    "    g2.add_edge((u, v), zx.EdgeType.HADAMARD)\n",
+    "ann = quizx.RankwidthAnnealer(g2)\n",
+    "decomp = ann.run()\n",
+    "decomp2 = quizx.DecompTree.from_list(decomp.to_list())\n",
+    "# decomp.clear_ranks()\n",
+    "print(decomp.to_list())\n",
+    "print(decomp.rankwidth(g2))\n",
+    "print(decomp2.to_list())\n",
+    "print(decomp2.rankwidth(g2))\n",
+    "\n",
+    "print(decomp)\n",
+    "print(decomp2)\n",
+    "\n",
+    "print(decomp.is_valid_for_graph(g2))\n",
+    "print(decomp2.is_valid_for_graph(g2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9a3479b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[5], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m \u001b[43mtest_rw_annealer\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[1;32mIn[4], line 22\u001b[0m, in \u001b[0;36mtest_rw_annealer\u001b[1;34m()\u001b[0m\n\u001b[0;32m     20\u001b[0m ann \u001b[38;5;241m=\u001b[39m quizx\u001b[38;5;241m.\u001b[39mRankwidthAnnealer(g2)\n\u001b[0;32m     21\u001b[0m decomp \u001b[38;5;241m=\u001b[39m ann\u001b[38;5;241m.\u001b[39mrun()\n\u001b[1;32m---> 22\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m quizx\u001b[38;5;241m.\u001b[39mDecompTree\u001b[38;5;241m.\u001b[39mfrom_list(decomp\u001b[38;5;241m.\u001b[39mto_list())\u001b[38;5;241m.\u001b[39mrankwidth(g2) \u001b[38;5;241m==\u001b[39m decomp\u001b[38;5;241m.\u001b[39mrankwidth(g2)\n",
+      "\u001b[1;31mAssertionError\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "test_rw_annealer()"
    ]
   },
   {


### PR DESCRIPTION
Clear cutrank cache after moving subtree. It is probably not necessary to clear the whole cache, but this is a simple solution for now.